### PR TITLE
Ship the terminology data the app needs to start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,9 @@ yarn-error.log*
 /public/icons
 /public/favicon.ico
 /public/*.json
+# ...except the terminology, which boot/i18n.ts fetches at startup. Without it
+# the app cannot start, so it has to be part of a checkout.
+!/public/terminology_EN.json
+!/public/terminology_DE.json
 /license-templates
 deploy.sh

--- a/public/terminology_DE.json
+++ b/public/terminology_DE.json
@@ -1,0 +1,1840 @@
+{
+    "title": "Das Omaha-System",
+    "problemClassificationScheme": {
+        "title": "Problemklassifikationsschema",
+        "domains": {
+            "01": {
+                "title": "Umwelt- und Lebensbereich",
+                "description": "Materielle Ressourcen und physische Bedingungen innerhalb und außerhalb des eigenen Wohnbereichs, der Nachbarschaft und der weiteren Gemeinschaft.",
+                "problems": {
+                    "01": {
+                        "title": "Einkommen",
+                        "description": "Geld aus Löhnen, Renten, Zuschüssen, Zinsen, Dividenden oder anderen Quellen, die für Lebens- und Gesundheitsausgaben zur Verfügung stehen.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "geringes/kein Einkommen"
+                            },
+                            "02": {
+                                "title": "nicht versicherte medizinische Ausgaben"
+                            },
+                            "03": {
+                                "title": "Schwierigkeiten bei der Geldverwaltung"
+                            },
+                            "04": {
+                                "title": "in der Lage nur das Lebensnotwendige zu kaufen"
+                            },
+                            "05": {
+                                "title": "Schwierigkeiten das Lebensnotwendige zu kaufen"
+                            },
+                            "06": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "02": {
+                        "title": "Hygiene im Haushalt",
+                        "description": "Sauberkeit der Umgebung und Schutzmaßnahmen gegen Infektionen und Krankheiten",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "sonstige"
+                            },
+                            "11": {
+                                "title": "Schimmelbefall"
+                            },
+                            "12": {
+                                "title": "übermäßig viele Haustiere"
+                            },
+                            "01": {
+                                "title": "verschmutzter Wohnbereich"
+                            },
+                            "02": {
+                                "title": "unzureichende Lagerung/Entsorgung von Lebensmitteln"
+                            },
+                            "03": {
+                                "title": "Insekten/Nagetiere"
+                            },
+                            "04": {
+                                "title": "unangenehmer Geruch"
+                            },
+                            "05": {
+                                "title": "unzureichende Wasserversorgung"
+                            },
+                            "06": {
+                                "title": "unzureichende Abwasserentsorgung"
+                            },
+                            "07": {
+                                "title": "Unzureichende Waschmöglichkeiten für Kleidung"
+                            },
+                            "08": {
+                                "title": "Allergene"
+                            },
+                            "09": {
+                                "title": "infektiöse/giftige Stoffe"
+                            }
+                        }
+                    },
+                    "03": {
+                        "title": "Wohnsitz",
+                        "description": "Wohnbereich.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "unsichere Geräte/Ausstattung"
+                            },
+                            "11": {
+                                "title": "unzureichende/beengte Wohnverhältnisse"
+                            },
+                            "12": {
+                                "title": "obdachlos"
+                            },
+                            "13": {
+                                "title": "sonstige"
+                            },
+                            "14": {
+                                "title": "freiliegende elektrische Leitungen"
+                            },
+                            "15": {
+                                "title": "bauliche Barrieren"
+                            },
+                            "01": {
+                                "title": "Mängel an der Bausubstanz"
+                            },
+                            "02": {
+                                "title": "unzureichende Heizung/Kühlung"
+                            },
+                            "03": {
+                                "title": "steile/unsichere Treppen"
+                            },
+                            "04": {
+                                "title": "unzureichende/versperrte Ein-/Ausgänge"
+                            },
+                            "05": {
+                                "title": "überladener Wohnraum"
+                            },
+                            "06": {
+                                "title": "unsichere Lagerung von gefährlichen Gegenständen/Stoffen"
+                            },
+                            "07": {
+                                "title": "unsichere Matten/Teppiche"
+                            },
+                            "08": {
+                                "title": "unzureichende Sicherheitsvorrichtungen"
+                            },
+                            "09": {
+                                "title": "Vorhandensein von bleihaltiger Farbe"
+                            }
+                        }
+                    },
+                    "04": {
+                        "title": "Sicheres Wohn- und Arbeitsumfeld",
+                        "description": "Freiheit von Krankheit, Verletzung oder Verlust in der Gemeinschaft des Wohn- oder Arbeitsortes.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "chemische Gefahren"
+                            },
+                            "11": {
+                                "title": "radiologische Gefahren"
+                            },
+                            "01": {
+                                "title": "hohe Kriminalitätsrate"
+                            },
+                            "02": {
+                                "title": "hohe Schadstoffbelastung"
+                            },
+                            "03": {
+                                "title": "unbeaufsichtigte/gefährliche/infizierte Tiere"
+                            },
+                            "05": {
+                                "title": "unzureichende/unsichere Spiel-/Trainingsbereiche"
+                            },
+                            "07": {
+                                "title": "unzureichender Raum/Ressourcen zur Förderung der Gesundheit"
+                            },
+                            "08": {
+                                "title": "Gewaltandrohungen/Berichte von Gewalt"
+                            },
+                            "04": {
+                                "title": "physikalische Gefahren"
+                            },
+                            "09": {
+                                "title": "Gefahren im Straßenverkehr"
+                            },
+                            "06": {
+                                "title": "sonstige"
+                            }
+                        }
+                    }
+                }
+            },
+            "02": {
+                "title": "Psychosozialer Bereich",
+                "description": "Verhaltensmuster, Gefühle, Kommunikation, Beziehungen und Entwicklung.",
+                "problems": {
+                    "10": {
+                        "title": "Spiritualität",
+                        "description": "Überzeugungen und Praktiken, die Glauben, Religion, Werte, Geist oder Seele betreffen.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "äußert spirituelle Bedenken/Sorgen"
+                            },
+                            "02": {
+                                "title": "Störung spiritueller Praktiken"
+                            },
+                            "03": {
+                                "title": "Störung spirituellen Vertrauens"
+                            },
+                            "04": {
+                                "title": "medizinische/gesundheitliche Behandlungen widersprechen den spirituellen Überzeugungen"
+                            },
+                            "05": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "11": {
+                        "title": "Trauer",
+                        "description": "Leiden und Belastungen im Zusammenhang mit Verlusterfahrungen.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "erkennt Trauerphasen/Heilungsprozess nicht"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten beim Umgang mit Trauerreaktionen"
+                            },
+                            "03": {
+                                "title": "Schwierigkeit, Trauer auszudrücken"
+                            },
+                            "04": {
+                                "title": "divergente Trauerphasen bei Individuen/Familien"
+                            },
+                            "05": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "12": {
+                        "title": "Psychische Gesundheit",
+                        "description": "Entwicklung und Einsatz von geistigen/emotionalen Fähigkeiten, um sich an Lebenssituationen anzupassen, mit anderen zu interagieren und Aktivitäten durchzuführen.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "somatische Beschwerden/Fatigue-Symptomatik"
+                            },
+                            "12": {
+                                "title": "sonstige"
+                            },
+                            "13": {
+                                "title": "eingeschränkte bis fragmentierte Aufmerksamkeit/Konzentration"
+                            },
+                            "14": {
+                                "title": "gereizt/agitiert/aggressiv"
+                            },
+                            "15": {
+                                "title": "zielloses/ungerichtetes Handeln, Zwangshandlungen "
+                            },
+                            "16": {
+                                "title": "Schwierigkeiten bei der Bewältigung von Wut"
+                            },
+                            "17": {
+                                "title": "wahnhaftes Denken/Erleben"
+                            },
+                            "18": {
+                                "title": "Halluzinationen/Fehlwahrnehmungen"
+                            },
+                            "19": {
+                                "title": "äußert Suizidgedanken/Tötungsgedanken"
+                            },
+                            "20": {
+                                "title": "versuchter Selbstmord/Mord"
+                            },
+                            "21": {
+                                "title": "Selbstverletzung"
+                            },
+                            "22": {
+                                "title": "Stimmungsschwankungen"
+                            },
+                            "23": {
+                                "title": "Flashbacks/Wiedererleben"
+                            },
+                            "01": {
+                                "title": "Traurigkeit/Hoffnungslosigkeit/vermindertes Selbstwertgefühl"
+                            },
+                            "02": {
+                                "title": "Besorgnis/unspezifische Angst"
+                            },
+                            "03": {
+                                "title": "Verlust von Interesse/Beteiligung an Aktivitäten/Selbstfürsorge"
+                            },
+                            "06": {
+                                "title": "flacher Affekt"
+                            },
+                            "09": {
+                                "title": "Schwierigkeiten beim Umgang mit Stress"
+                            }
+                        }
+                    },
+                    "13": {
+                        "title": "Sexualität",
+                        "description": "Einstellungen, Gefühle und Verhaltensweisen in Bezug auf Intimität und sexuelle Aktivität.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Schwierigkeiten die Folgen des Sexualverhaltens zu erkennen"
+                            },
+                            "02": {
+                                "title": "Schwierigkeit, Intimität auszudrücken"
+                            },
+                            "03": {
+                                "title": "Unsicherheit bezüglich der geschlechtlichen Identität"
+                            },
+                            "04": {
+                                "title": "Unsicherheit bezüglich sexueller Werte"
+                            },
+                            "05": {
+                                "title": "unzufrieden mit sexuellen Beziehungen"
+                            },
+                            "07": {
+                                "title": "unsichere Sexualpraktiken"
+                            },
+                            "08": {
+                                "title": "Sexuell provokatives Verhalten/Belästigung"
+                            },
+                            "09": {
+                                "title": "Sexualvergehen/sexuelle Übergriffe"
+                            },
+                            "06": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "14": {
+                        "title": "Betreuung/Kindererziehung",
+                        "description": "Unterstützung, Zuwendung, Förderung und körperliche Versorgung für abhängige Kinder und Erwachsene.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "Schwierigkeiten beim Interpretieren oder Antworten auf verbale/nonverbale Kommunikation"
+                            },
+                            "01": {
+                                "title": "Schwierigkeiten körperliche Versorgung/Sicherheit zu gewährleisten"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten, emotionale Zuwendung zu bieten"
+                            },
+                            "03": {
+                                "title": "Schwierigkeiten kognitive Lernerfahrungen und -aktivitäten anzubieten"
+                            },
+                            "04": {
+                                "title": "Schwierigkeiten präventive und therapeutischer Gesundheitsversorgung zu gewährleisten"
+                            },
+                            "05": {
+                                "title": "Erwartungen, die mit dem Wachstums- und Entwicklungsstadium nicht übereinstimmen"
+                            },
+                            "06": {
+                                "title": "Unzufriedenheit/Schwierigkeiten mit Verantwortung"
+                            },
+                            "07": {
+                                "title": "vernachlässigend"
+                            },
+                            "08": {
+                                "title": "missbräuchlich"
+                            },
+                            "09": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "15": {
+                        "title": "Vernachlässigung",
+                        "description": "Kind oder Erwachsener, dem die Mindeststandards für Nahrung, Unterkunft, Kleidung oder Fürsorge vorenthalten werden.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Mangel an angemessener körperlicher Versorgung"
+                            },
+                            "02": {
+                                "title": "Fehlende emotionale Zuwendung/Unterstützung"
+                            },
+                            "03": {
+                                "title": "Fehlen geeigneter kognitiver Lernerfahrungen und -anreize"
+                            },
+                            "04": {
+                                "title": "unangemessenerweise allein gelassen"
+                            },
+                            "05": {
+                                "title": "Fehlen einer notwendigen Beaufsichtigung"
+                            },
+                            "06": {
+                                "title": "unzureichende/verzögerte medizinische Versorgung"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "16": {
+                        "title": "Missbrauch",
+                        "description": "Kind oder Erwachsener, der beabsichtigter körperlicher, emotionaler oder sexueller Gewalt oder Verletzung ausgesetzt ist.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "strenge/übertriebene Disziplin"
+                            },
+                            "02": {
+                                "title": "Prellungen/Hämatome/Verbrennungen/andere Verletzungen"
+                            },
+                            "03": {
+                                "title": "fragwürdige Erklärung der Verletzung"
+                            },
+                            "04": {
+                                "title": "wird verbal angegriffen"
+                            },
+                            "05": {
+                                "title": "ängstliches/übervorsichtiges Verhalten"
+                            },
+                            "06": {
+                                "title": "gewalttätige Umgebung"
+                            },
+                            "07": {
+                                "title": "fortwährend negative Rückmeldungen"
+                            },
+                            "08": {
+                                "title": "sexuellem Übergriff zum Opfer fallen/sexuell misshandelt"
+                            },
+                            "09": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "17": {
+                        "title": "Wachstum und Entwicklung",
+                        "description": "Kontinuierliche, dem Alter entsprechende körperliche, emotionale und soziale Reifung von der Geburt bis zum Tod.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "anormale Ergebnisse bei Entwicklungstests"
+                            },
+                            "02": {
+                                "title": "anormales Gewicht/Körpergröße/Kopfumfang im Verhältnis zur Wachstums-/Altersnorm"
+                            },
+                            "03": {
+                                "title": "dem Alter unangemessenes Verhalten"
+                            },
+                            "04": {
+                                "title": "unzureichende Bewältigung/Aufrechterhaltung von entwicklungsbezogenen Aufgaben"
+                            },
+                            "05": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "06": {
+                        "title": "Kommunikation mit den kommunalen Einrichtungen",
+                        "description": "Interaktion zwischen dem Einzelnen, der Familie oder Gemeinschaft und sozialen Einrichtungen, Schulen und Unternehmen in Bezug auf Dienstleistungen, Informationen, Güter oder Versorgung.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "Verkehrsbarriere"
+                            },
+                            "11": {
+                                "title": "eingeschränkter Zugang zu Pflege/Dienstleistungen/Gütern"
+                            },
+                            "12": {
+                                "title": "unzureichende Fähigkeiten zur Nutzung/Verfügbarkeit von Kommunikationsmitteln"
+                            },
+                            "01": {
+                                "title": "nicht vertraut mit Möglichkeiten/Abläufen zur Inanspruchnahme von Dienstleistungen"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten beim Verständnis von Aufgaben/Vorschriften der Dienstleister"
+                            },
+                            "03": {
+                                "title": "nicht in der Lage, dem Anbieter Anliegen oder Bedenken mitzuteilen"
+                            },
+                            "04": {
+                                "title": "Unzufriedenheit mit den Dienstleistungen"
+                            },
+                            "06": {
+                                "title": "ungeeignete/nicht verfügbare Hilfsmittel"
+                            },
+                            "05": {
+                                "title": "Sprachbarriere"
+                            },
+                            "08": {
+                                "title": "kulturelle Barriere"
+                            },
+                            "09": {
+                                "title": "Bildungsbarriere"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "07": {
+                        "title": "Sozialer Kontakt",
+                        "description": "Interaktion zwischen dem Einzelnen, der Familie oder Gemeinschaft und anderen außerhalb des unmittelbaren Wohnbereichs.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "begrenzter sozialer Kontakt"
+                            },
+                            "02": {
+                                "title": "nutzt Gesundheitsdienstleister für den sozialen Kontakt"
+                            },
+                            "03": {
+                                "title": "minimale äußere Anreize/Freizeitaktivitäten"
+                            },
+                            "04": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "08": {
+                        "title": "Rollenwechsel",
+                        "description": "Hinzufügen oder Entfernen einer Reihe von erwarteten Verhaltensmerkmalen.",
+                        "signsAndSymptoms": {
+                            "06": {
+                                "title": "unfreiwilliger Rollentausch"
+                            },
+                            "03": {
+                                "title": "nimmt eine neue Rolle an"
+                            },
+                            "04": {
+                                "title": "verliert eine vorherige Rolle"
+                            },
+                            "05": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "09": {
+                        "title": "Zwischenmenschliche Beziehungen",
+                        "description": "Verbindungen zwischen Einzelpersonen/Familie/Gemeinschaft und anderen.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "Schwierigkeit, ein Problem ohne Konflikt zu lösen"
+                            },
+                            "01": {
+                                "title": "Schwierigkeit beim Aufbau/Erhalt von Beziehungen"
+                            },
+                            "02": {
+                                "title": "wenige gemeinsame Aktivitäten"
+                            },
+                            "03": {
+                                "title": "abweichende Werte/Ziele/Erwartungen/Pläne"
+                            },
+                            "04": {
+                                "title": "ungeeignete zwischenmenschliche Kommunikationsfähigkeit"
+                            },
+                            "05": {
+                                "title": "anhaltende, nicht gelöste Spannung"
+                            },
+                            "08": {
+                                "title": "unangemessesne Verdächtigung/Manipulation/Kontrolle"
+                            },
+                            "09": {
+                                "title": "körperlicher/emotionaler Missbrauch gegenüber dem Partner"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    }
+                }
+            },
+            "03": {
+                "title": "Physiologischer Bereich",
+                "description": "Funktionen und Prozesse, die das Leben erhalten.",
+                "problems": {
+                    "19": {
+                        "title": "Hörvermögen",
+                        "description": "Wahrnehmung von Geräuschen mit den Ohren.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Schwierigkeiten beim Hören normaler Sprachtöne"
+                            },
+                            "05": {
+                                "title": "Schwierigkeiten beim Hören von Gesprochenem in großen Gruppen"
+                            },
+                            "06": {
+                                "title": "Schwierigkeiten beim Hören von Tönen höherer Frequenz"
+                            },
+                            "02": {
+                                "title": "fehlende/anormale Reaktion auf Geräusche"
+                            },
+                            "03": {
+                                "title": "anormale Ergebnisse beim Hörtest"
+                            },
+                            "04": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "20": {
+                        "title": "Sehvermögen",
+                        "description": "Wahrnehmung mit den Augen.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Schwierigkeiten Kleingedrucktes zu lesen"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten beim Sehen entfernter Objekte"
+                            },
+                            "03": {
+                                "title": "Schwierigkeiten beim Sehen von nahen Objekten"
+                            },
+                            "04": {
+                                "title": "fehlende/anormale Reaktion auf visuelle Stimuli"
+                            },
+                            "05": {
+                                "title": "anormale Ergebnisse beim Sehtest"
+                            },
+                            "06": {
+                                "title": "schielen/blinzeln/tränen/verschwimmen"
+                            },
+                            "09": {
+                                "title": "Glaskörpertrübungen/Mouches volantes/Blitzlichter"
+                            },
+                            "07": {
+                                "title": "Schwierigkeiten, Farben zu unterscheiden"
+                            },
+                            "08": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "21": {
+                        "title": "Sprechen und Sprache",
+                        "description": "Gebrauch von artikulierten Stimmlauten, Symbolen, Zeichen oder Gesten zur Kommunikation.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "fehlende/anormale Fähigkeit zu reden/auszusprechen"
+                            },
+                            "02": {
+                                "title": "fehlende/anormale Fähigkeit zu verstehen"
+                            },
+                            "03": {
+                                "title": "Mangel an alternativen Kommunikationsfähigkeiten/Gesten"
+                            },
+                            "04": {
+                                "title": "unpassende Satzstruktur"
+                            },
+                            "05": {
+                                "title": "eingeschränkte Ausdrucksweise/Deutlichkeit"
+                            },
+                            "06": {
+                                "title": "unpassender Wortgebrauch"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "23": {
+                        "title": "Kognition",
+                        "description": "Fähigkeit zu denken und Informationen zu verarbeiten.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "sonstige"
+                            },
+                            "11": {
+                                "title": "irrt sich"
+                            },
+                            "01": {
+                                "title": "vermindertes Urteilsvermögen"
+                            },
+                            "02": {
+                                "title": "desorientiert in Bezug auf Zeit/Ort/Person"
+                            },
+                            "03": {
+                                "title": "begrenzte Erinnerung an kürzliche Ereignisse"
+                            },
+                            "04": {
+                                "title": "begrenzte Erinnerung an lang zurückliegende Ereignisse"
+                            },
+                            "05": {
+                                "title": "begrenzte Fähigkeiten im Rechnen/Zählen"
+                            },
+                            "06": {
+                                "title": "eingeschränkte Konzentration"
+                            },
+                            "07": {
+                                "title": "eingeschränktes logisches/abstraktes Denken"
+                            },
+                            "08": {
+                                "title": "Impulsivität"
+                            },
+                            "09": {
+                                "title": "wiederholende Erzählungen/Verhalten"
+                            }
+                        }
+                    },
+                    "24": {
+                        "title": "Schmerz",
+                        "description": "Unangenehme sensorische und emotionale Erfahrungen, die mit tatsächlichen oder potenziellen Gewebeschäden verbunden sind.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "äußert Unwohlsein/Schmerz"
+                            },
+                            "02": {
+                                "title": "erhöhter Puls/Atmung/Blutdruck"
+                            },
+                            "03": {
+                                "title": "kompensierende Bewegung/Schonhaltung"
+                            },
+                            "04": {
+                                "title": "ruheloses Verhalten"
+                            },
+                            "05": {
+                                "title": "Gesichtsgrimassen"
+                            },
+                            "06": {
+                                "title": "Blässe/Schwitzen"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "25": {
+                        "title": "Bewusstsein",
+                        "description": "Wahrnehmung und Reaktionsfähigkeit auf Stimuli und Umgebung.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "lethargisch"
+                            },
+                            "02": {
+                                "title": "Stupor"
+                            },
+                            "03": {
+                                "title": "reaktionslos"
+                            },
+                            "04": {
+                                "title": "komatös"
+                            },
+                            "05": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "26": {
+                        "title": "Haut",
+                        "description": "Natürliche Hülle des Körpers.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "sonstige"
+                            },
+                            "11": {
+                                "title": "verzögerte Wundheilung"
+                            },
+                            "01": {
+                                "title": "Läsion/Dekubitus"
+                            },
+                            "02": {
+                                "title": "Hautausschlag/Effloreszenz"
+                            },
+                            "03": {
+                                "title": "übermäßig trocken"
+                            },
+                            "04": {
+                                "title": "übermäßig ölig"
+                            },
+                            "05": {
+                                "title": "Entzündung"
+                            },
+                            "06": {
+                                "title": "Pruritus"
+                            },
+                            "07": {
+                                "title": "Drainage"
+                            },
+                            "08": {
+                                "title": "Hämatom"
+                            },
+                            "09": {
+                                "title": "Hypertrophie der Nägel"
+                            }
+                        }
+                    },
+                    "27": {
+                        "title": "Neuromuskulo-skelettale Funktion",
+                        "description": "Fähigkeit von Nerven, Muskeln und Knochen, gezielte Bewegungen, Empfindungen oder Steuerungen auszuführen oder zu koordinieren.",
+                        "signsAndSymptoms": {
+                            "11": {
+                                "title": "Tremor/Krampfanfall"
+                            },
+                            "12": {
+                                "title": "sonstige"
+                            },
+                            "13": {
+                                "title": "Schwierigkeiten beim Transfer"
+                            },
+                            "14": {
+                                "title": "Frakturen"
+                            },
+                            "15": {
+                                "title": "Schwierigkeiten mit der Thermoregulation"
+                            },
+                            "01": {
+                                "title": "eingeschränkte Bewegungsfreiheit"
+                            },
+                            "02": {
+                                "title": "verminderte Muskelkraft"
+                            },
+                            "03": {
+                                "title": "verminderte Koordination"
+                            },
+                            "04": {
+                                "title": "verminderter Muskeltonus"
+                            },
+                            "05": {
+                                "title": "erhöhter Muskeltonus"
+                            },
+                            "06": {
+                                "title": "verminderte Sinnesempfindung"
+                            },
+                            "07": {
+                                "title": "gesteigerte Sinnesempfindung"
+                            },
+                            "08": {
+                                "title": "Gleichgewichtsstörung"
+                            },
+                            "09": {
+                                "title": "Gangstörung"
+                            }
+                        }
+                    },
+                    "28": {
+                        "title": "Atmung",
+                        "description": "Ein- und Ausatmen von Luft in den Körper und Sauerstoffaustausch.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "sonstige"
+                            },
+                            "11": {
+                                "title": "anormale respiratorische Laborergebnisse"
+                            },
+                            "01": {
+                                "title": "anormale Atemmuster"
+                            },
+                            "02": {
+                                "title": "nicht in der Lage selbstständig zu atmen"
+                            },
+                            "03": {
+                                "title": "Husten"
+                            },
+                            "04": {
+                                "title": "nicht in der Lage selbstständig zu husten/abzuhusten"
+                            },
+                            "05": {
+                                "title": "Zyanose"
+                            },
+                            "06": {
+                                "title": "anormales Sputum"
+                            },
+                            "07": {
+                                "title": "geräuschvolle Atemzüge"
+                            },
+                            "08": {
+                                "title": "Rhinitis/verstopfte Nase"
+                            },
+                            "09": {
+                                "title": "anormale Atemgeräusche"
+                            }
+                        }
+                    },
+                    "29": {
+                        "title": "Kreislauf",
+                        "description": "Das Blut in angemessenen Mengen und Druck durch den Körper pumpen.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "unregelmäßige Herzfrequenz"
+                            },
+                            "11": {
+                                "title": "übermäßig schnelle Herzfrequenz"
+                            },
+                            "12": {
+                                "title": "übermäßig langsame Herzfrequenz"
+                            },
+                            "13": {
+                                "title": "Anginalschmerzen"
+                            },
+                            "14": {
+                                "title": "anormale Herztöne/Herzgeräusche"
+                            },
+                            "15": {
+                                "title": "sonstige"
+                            },
+                            "16": {
+                                "title": "anormale Gerinnung"
+                            },
+                            "17": {
+                                "title": "anormale kardiale Laborergebnisse"
+                            },
+                            "01": {
+                                "title": "Ödem"
+                            },
+                            "02": {
+                                "title": "Krämpfe/Schmerzen in den Extremitäten"
+                            },
+                            "03": {
+                                "title": "niedriger Puls"
+                            },
+                            "04": {
+                                "title": "Hautkolorit"
+                            },
+                            "05": {
+                                "title": "Temperaturveränderung im betroffenen Bereich"
+                            },
+                            "06": {
+                                "title": "Varizen"
+                            },
+                            "07": {
+                                "title": "Synkopen (Ohnmacht)/Schwindelgefühl"
+                            },
+                            "08": {
+                                "title": "anormale Werte bei Blutdruckmessung"
+                            },
+                            "09": {
+                                "title": "Pulsdefizit"
+                            }
+                        }
+                    },
+                    "30": {
+                        "title": "Nahrungsaufnahme, Verdauung und Flüssigkeitshaushalt",
+                        "description": "Prozess der Absorption von Nahrungsmitteln, sowie des Flüssigkeitshaushalts.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "spröde Lippen/trockener Mund"
+                            },
+                            "11": {
+                                "title": "Elektrolytungleichgewicht"
+                            },
+                            "12": {
+                                "title": "sonstige"
+                            },
+                            "01": {
+                                "title": "Nausea/Brechreiz"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten/Unvermögen zu kauen/schlucken/verdauen"
+                            },
+                            "03": {
+                                "title": "Verdauungsstörung"
+                            },
+                            "04": {
+                                "title": "Reflux"
+                            },
+                            "05": {
+                                "title": "Anorexie"
+                            },
+                            "06": {
+                                "title": "Anämie"
+                            },
+                            "07": {
+                                "title": "Aszites"
+                            },
+                            "08": {
+                                "title": "Ikterus/Lebervergrößerung"
+                            },
+                            "09": {
+                                "title": "verminderter Hautturgor"
+                            }
+                        }
+                    },
+                    "31": {
+                        "title": "Darmfunktion",
+                        "description": "Transport von Nahrung durch den Gastrointestinaltrakt zur Ausscheidung von Abfällen.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "anormale Häufigkeit/Konsistenz des Stuhlgangs"
+                            },
+                            "02": {
+                                "title": "schmerzhafter Stuhlgang"
+                            },
+                            "03": {
+                                "title": "verminderte Darmgeräusche"
+                            },
+                            "04": {
+                                "title": "Blut im Stuhlgang"
+                            },
+                            "05": {
+                                "title": "anormale Farbe"
+                            },
+                            "06": {
+                                "title": "Krämpfe/Abdominalschmerzen"
+                            },
+                            "07": {
+                                "title": "Stuhlinkontinenz"
+                            },
+                            "08": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "45": {
+                        "title": "Mundhygiene",
+                        "description": "Zustand von Mund und Zahnfleisch sowie Anzahl, Art und Anordnung der Zähne.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "fehlende/kaputte/deformierte Zähne"
+                            },
+                            "02": {
+                                "title": "Karies"
+                            },
+                            "03": {
+                                "title": "übermäßig viel Zahnstein"
+                            },
+                            "04": {
+                                "title": "schmerzendes/geschwollenes/blutendes Zahnfleisch"
+                            },
+                            "05": {
+                                "title": "Zahnfehlstellung"
+                            },
+                            "06": {
+                                "title": "schlecht sitzende/fehlende Zahnprothese"
+                            },
+                            "07": {
+                                "title": "Empfindlichkeit gegen Hitze oder Kälte"
+                            },
+                            "08": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "46": {
+                        "title": "Harnfunktion",
+                        "description": "Produktion und Ausscheidung von Urin.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "sonstige"
+                            },
+                            "01": {
+                                "title": "brennendes/schmerzhaftes Wasserlassen"
+                            },
+                            "02": {
+                                "title": "Harninkontinenz"
+                            },
+                            "03": {
+                                "title": "Harndrang/-häufigkeit"
+                            },
+                            "04": {
+                                "title": "Schwierigkeiten das Urinieren zu initiieren"
+                            },
+                            "05": {
+                                "title": "unvollständige Blasenentleerung"
+                            },
+                            "06": {
+                                "title": "anormale Menge"
+                            },
+                            "07": {
+                                "title": "Hämaturie/anormale Farbe"
+                            },
+                            "08": {
+                                "title": "Nykturie"
+                            },
+                            "09": {
+                                "title": "Anormale Ergebnisse beim Urintest"
+                            }
+                        }
+                    },
+                    "47": {
+                        "title": "Reproduktionsfunktion",
+                        "description": "Zustand der Genitalien und Brüste und die Fähigkeit zur Fortpflanzung.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "anormaler Ausfluss"
+                            },
+                            "02": {
+                                "title": "anormales Menstruationsmuster"
+                            },
+                            "03": {
+                                "title": "Schwierigkeiten bei der Bewältigung der Menopause/Andropause"
+                            },
+                            "04": {
+                                "title": "Anomale Knoten/Schwellung/Spannung an Genitalien oder Brüsten"
+                            },
+                            "05": {
+                                "title": "Schmerzen während oder nach dem Coitus"
+                            },
+                            "06": {
+                                "title": "Unfruchtbarkeit"
+                            },
+                            "07": {
+                                "title": "Impotenz"
+                            },
+                            "08": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "48": {
+                        "title": "Schwangerschaft",
+                        "description": "Zeitraum von der Empfängnis bis zur Geburt.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Schwierigkeiten eine Bindung zum ungeborenen Baby aufzubauen"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten Körperveränderungen anzunehmen"
+                            },
+                            "03": {
+                                "title": "Schwierigkeiten mit pränatalen Übungen/Ruhe/Ernährung/Verhalten"
+                            },
+                            "04": {
+                                "title": "Ängste bezüglich der Entbindung"
+                            },
+                            "05": {
+                                "title": "pränatale Komplikationen/vorzeitige Wehen"
+                            },
+                            "06": {
+                                "title": "unzureichende soziale Unterstützung"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "49": {
+                        "title": "Postpartum",
+                        "description": "Der Zeitraum von sechs Wochen nach der Geburt.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Schwierigkeiten beim Stillen"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten beim Umgang mit postpartalen Veränderungen"
+                            },
+                            "03": {
+                                "title": "Schwierigkeiten mit postpartalen Übungen/Ruhe/Ernährung/Verhalten"
+                            },
+                            "04": {
+                                "title": "anormale Blutung/fluor genitalis"
+                            },
+                            "05": {
+                                "title": "postpartale Komplikationen"
+                            },
+                            "06": {
+                                "title": "Wochenbettdepression"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "50": {
+                        "title": "Übertragbare/infektiöse Erkrankung",
+                        "description": "Zustand, bei dem Organismen den Körper befallen und lokale oder systemische Erkrankungen hervorrufen mit dem Potenzial der Ausbreitung oder Übertragung.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Infektion"
+                            },
+                            "02": {
+                                "title": "Infestation"
+                            },
+                            "03": {
+                                "title": "Fieber"
+                            },
+                            "04": {
+                                "title": "biologische Gefahren"
+                            },
+                            "05": {
+                                "title": "positives Screening/Kulturbefund/Laborergebnisse"
+                            },
+                            "06": {
+                                "title": "unzureichende Hilfsmittel/Ausstattung/Richtlinien zur Verhinderung der Übertragung"
+                            },
+                            "07": {
+                                "title": "befolgt die Richtlinien zur Eindämmung von Infektionskrankheiten nicht"
+                            },
+                            "08": {
+                                "title": "unzureichende Immunität"
+                            },
+                            "09": {
+                                "title": "sonstige"
+                            }
+                        }
+                    }
+                }
+            },
+            "04": {
+                "title": "Bereich gesundheitsbezogenes Verhalten",
+                "description": "Aktivitäten, die das Wohlbefinden erhalten oder fördern, die Genesung stärken und das Risiko von Krankheiten verringern.",
+                "problems": {
+                    "35": {
+                        "title": "Ernährung",
+                        "description": "Auswahl und Konsum von Lebensmitteln und Flüssigkeiten um Energie, Wachstum und Gesundheit aufrechtzuerhalten.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "Hyperglykämie"
+                            },
+                            "11": {
+                                "title": "sonstige"
+                            },
+                            "12": {
+                                "title": "Übergewicht: Erwachsener BMI von 25,0 oder mehr; Kind BMI von 95. Altersperzentile oder mehr"
+                            },
+                            "13": {
+                                "title": "Untergewicht: Erwachsener BMI von 18,5 oder weniger; Kind BMI von 5. Altersperzentile oder weniger"
+                            },
+                            "14": {
+                                "title": "Unfähigkeit Lebensmittel zu beschaffen/zuzubereiten"
+                            },
+                            "03": {
+                                "title": "unterschreitet etablierte Standards für die tägliche Kalorien-/Flüssigkeitszufuhr"
+                            },
+                            "04": {
+                                "title": "überschreitet etablierte Standards für die tägliche Kalorien-/Flüssigkeitszufuhr"
+                            },
+                            "05": {
+                                "title": "unausgewogene Ernährung"
+                            },
+                            "06": {
+                                "title": "ungeeigneter Essenszeitplan für das jeweilige Alter"
+                            },
+                            "07": {
+                                "title": "folgt nicht dem empfohlenen Ernährungsplan"
+                            },
+                            "08": {
+                                "title": "unerklärlicher/fortschreitender Gewichtsverlust"
+                            },
+                            "09": {
+                                "title": "Hypoglykämie"
+                            }
+                        }
+                    },
+                    "36": {
+                        "title": "Schlaf- und Ruhezeiten",
+                        "description": "Zeiträume ohne motorische und sensorische Aktivität und Zeiträume der Inaktivität, Ruhe oder geistigen Stille.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "Schlaf-/Ruhezeiten beeinträchtigt die Familie"
+                            },
+                            "02": {
+                                "title": "wacht nachts häufig auf"
+                            },
+                            "03": {
+                                "title": "Schlafwandeln"
+                            },
+                            "04": {
+                                "title": "Schlaflosigkeit"
+                            },
+                            "05": {
+                                "title": "Albträume"
+                            },
+                            "06": {
+                                "title": "unzureichender Schlaf/Ruhe für das jeweilige Alter/die körperliche Verfassung"
+                            },
+                            "08": {
+                                "title": "Schlafapnoe"
+                            },
+                            "09": {
+                                "title": "Schnarchen"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "37": {
+                        "title": "Körperliche Aktivität",
+                        "description": "Zustand oder Qualität der Bewegungsfähigkeit im Alltag.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "bewegungsarmer Lebensstil"
+                            },
+                            "02": {
+                                "title": "ungeeignete/uneinheitliche Trainingsroutine"
+                            },
+                            "03": {
+                                "title": "unangemessene Art/Menge der Bewegung für das jeweilige Alter/für die körperliche Verfassung"
+                            },
+                            "04": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "38": {
+                        "title": "Körperpflege",
+                        "description": "Handhabung der persönlichen Sauberkeit und Kleidung.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "unwillig/unfähig/vergisst die Körperpflege durchzuführen"
+                            },
+                            "01": {
+                                "title": "Schwierigkeiten beim Wäsche waschen"
+                            },
+                            "02": {
+                                "title": "Schwierigkeiten bei der Körperwäsche "
+                            },
+                            "07": {
+                                "title": "Schwierigkeiten bei Toilettengängen"
+                            },
+                            "08": {
+                                "title": "Schwierigkeiten beim Anziehen des Unterkörpers"
+                            },
+                            "09": {
+                                "title": "Schwierigkeiten beim Anziehen des Oberkörpers"
+                            },
+                            "03": {
+                                "title": "unangenehmer Körpergeruch"
+                            },
+                            "04": {
+                                "title": "Schwierigkeiten beim Waschen/Kämmen der Haare"
+                            },
+                            "05": {
+                                "title": "Schwierigkeiten bei der Mundpflege (z.B. Zähne putzen, Zahnseide verwenden)"
+                            },
+                            "06": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "39": {
+                        "title": "Substanzkonsum",
+                        "description": "Konsum von Medikamenten, Freizeitdrogen oder anderen Substanzen, die Stimmungen verändern und/oder psychische/physische Abhängigkeit und Erkrankung verursachen.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "ist Tabakrauch ausgesetzt"
+                            },
+                            "11": {
+                                "title": "kauft/verkauft illegale Substanzen"
+                            },
+                            "08": {
+                                "title": "Missbrauch von rezeptfreien/verschreibungspflichtigen Medikamenten"
+                            },
+                            "09": {
+                                "title": "konsumiert Freizeitdrogen"
+                            },
+                            "02": {
+                                "title": "missbraucht Alkohol"
+                            },
+                            "03": {
+                                "title": "raucht/konsumiert Tabakwaren"
+                            },
+                            "04": {
+                                "title": "Schwierigkeiten bei der Durchführung normaler Routinen"
+                            },
+                            "05": {
+                                "title": "Reflexstörungen"
+                            },
+                            "06": {
+                                "title": "Verhaltensänderung"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "40": {
+                        "title": "Familienplanung",
+                        "description": "Praktiken zur Planung und Gestaltung von Schwangerschaft im Kontext von Werten, Einstellungen und Überzeugungen.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "unangemessenes/unzureichendes Wissen über Familienplanungsmethoden"
+                            },
+                            "05": {
+                                "title": "unangemessenes/unzureichendes Wissen über Gesundheitspraktiken vor der Empfängnis"
+                            },
+                            "02": {
+                                "title": "ungenaue/uneinheitliche Anwendung von Familienplanungsmethoden"
+                            },
+                            "03": {
+                                "title": "unzufrieden mit der derzeitigen Familienplanungsmethode"
+                            },
+                            "06": {
+                                "title": "Angst vor den Reaktionen anderer auf die Entscheidung zur Familienplanung"
+                            },
+                            "07": {
+                                "title": "Schwierigkeiten beim Einholen von Familienplanungsmethoden"
+                            },
+                            "04": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "41": {
+                        "title": "Supervision der Gesundheitsversorgung",
+                        "description": "Verwaltung des Behandlungsplans durch Gesundheitsdienstleister.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "versäumt routinemäßige/präventive Gesundheitsversorgung"
+                            },
+                            "02": {
+                                "title": "versäumt erforderliche Untersuchung/Behandlung bei Symptomen"
+                            },
+                            "03": {
+                                "title": "versäumt die Wiedervorstellung beim Gesundheitsdienstleister"
+                            },
+                            "04": {
+                                "title": "Unfähigkeit mehrere Termine/Behandlungspläne zu koordinieren"
+                            },
+                            "05": {
+                                "title": "uneinheitliche Gesundheitsversorgung"
+                            },
+                            "08": {
+                                "title": "ungeeignete Gesundheitsversorgung"
+                            },
+                            "06": {
+                                "title": "ungeeigneter Behandlungsplan"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    },
+                    "42": {
+                        "title": "Medikamentenmanagement",
+                        "description": "Gebrauch oder Anwendung von rezeptfreien/verschreibungspflichtigen Medikamenten und Infusionen gemäß den Leitlinien zur therapeutischen Wirkung, Sicherheit und Zeitplan.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "folgt nicht der empfohlenen Dosierung/Zeitplanung"
+                            },
+                            "02": {
+                                "title": "Hinweis auf Nebenwirkungen/unerwünschte Reaktionen"
+                            },
+                            "03": {
+                                "title": "ungeeignetes Vorgehen bei der Medikamenteneinnahme"
+                            },
+                            "04": {
+                                "title": "unsachgemäße Lagerung von Medikamenten"
+                            },
+                            "05": {
+                                "title": "versäumt die angemessene Besorgung von Nachschub"
+                            },
+                            "06": {
+                                "title": "versäumt Impfungen"
+                            },
+                            "08": {
+                                "title": "ungeeigneter Medikamentenplan"
+                            },
+                            "09": {
+                                "title": "nicht in der Lage, Medikamente ohne Hilfe einzunehmen"
+                            },
+                            "07": {
+                                "title": "sonstige"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "modifiers": {
+            "scope": {
+                "0": {
+                    "title": "Einzelperson",
+                    "description": "Eine allein lebende Person oder ein einzelnes Familienmitglied, das ein gesundheitliches Problem hat."
+                },
+                "1": {
+                    "title": "Familie",
+                    "description": "Eine soziale Einheit oder eine Gruppe von verwandten Personen, die zusammenleben und gemeinsam ein gesundheitliches Problem haben."
+                },
+                "2": {
+                    "title": "Gemeinschaft",
+                    "description": "Einzelpersonen und/oder Familien, die gemeinsam eine Gruppe, eine Nachbarschaft oder einen anderen geografischen Bezirk darstellen, und gemeinschaftlich ein gesundheitliches Problem haben."
+                }
+            },
+            "severity": {
+                "0": {
+                    "title": "Gesundheitsförderung",
+                    "description": "Klienteninteresse an der Verbesserung von Wissen, Verhalten und Gesundheitserwartungen, sowie an der Entwicklung von Ressourcen, die das Wohlbefinden erhalten oder verbessern, ohne dass Risikofaktoren oder Symptome vorliegen."
+                },
+                "1": {
+                    "title": "Risiko",
+                    "description": "Klient weist bestimmte gesundheitliche Muster, Verhaltensweisen oder Risikofaktoren auf, die eine optimale Gesundheit ausschließen können, ohne dass bereits erkennbare Symptome vorliegen."
+                },
+                "2": {
+                    "title": "Tatsächlich",
+                    "description": "Zustand des Klienten, der durch ein oder mehrere bestehende Symptome gekennzeichnet ist, die einer optimalen Gesundheit entgegenstehen können."
+                }
+            }
+        }
+    },
+    "interventionScheme": {
+        "title": "Interventionsschema",
+        "categories": {
+            "01": {
+                "title": "Unterricht, Anleitung und Beratung",
+                "description": "Aktivitäten, die darauf abzielen, Informationen und Materialien zur Verfügung zu stellen, zum Handeln und zur Übernahme von Verantwortung für die Selbstfürsorge und die Bewältigung von Problemen anzuregen und den Einzelnen, die Familie oder die Gemeinschaft dabei zu unterstützen, Entscheidungen zu treffen und Probleme zu lösen."
+            },
+            "02": {
+                "title": "Behandlungen und Verfahren",
+                "description": "Technische Tätigkeiten wie Wundversorgung, Probenentnahme, Widerstandsübungen und Verschreibung von Medikamenten, die darauf abzielen, Symptome für den Einzelnen, die Familie oder die Gemeinschaft zu verhindern, zu verringern oder zu lindern."
+            },
+            "03": {
+                "title": "Fallmanagement",
+                "description": "Aktivitäten wie Koordinierung, Interessenvertretung und Überweisung, die die Erbringung von Dienstleistungen erleichtern, die Durchsetzungsfähigkeit fördern, den Einzelnen, die Familie oder die Gemeinschaft zur Nutzung geeigneter Ressourcen anleiten und die Kommunikation zwischen den Anbietern von Gesundheits- und Humandienstleistungen verbessern."
+            },
+            "04": {
+                "title": "Überwachung",
+                "description": "Aktivitäten wie Erkennung, Messung, kritische Analyse und Überwachung, die dazu dienen, den Status des Einzelnen, der Familie oder der Gemeinschaft in Bezug auf einen bestimmten Zustand oder ein bestimmtes Phänomen zu ermitteln."
+            }
+        },
+        "targets": {
+            "10": {
+                "title": "Kommunikation",
+                "description": "Austausch von verbalen oder nonverbalen Informationen zwischen Einzelperson/Familie/Gemeinschaft und anderen."
+            },
+            "11": {
+                "title": "Bewältigungskompetenzen",
+                "description": "Fähigkeit, Herausforderungen und Veränderungen wie Krankheit, Behinderung, Einkommensverlust, die Geburt eines Kindes oder den Tod eines Familienmitglieds effektiv zu bewältigen."
+            },
+            "12": {
+                "title": "Tagesbetreuung/Ruhephasen",
+                "description": "Personen oder Organisationen, die die Beaufsichtigung von Kindern/Erwachsenen übernehmen, während die Eltern/gewöhnliche Betreuungsperson zur Schule gehen, arbeiten oder von ihren üblichen Pflichten entlastet werden."
+            },
+            "13": {
+                "title": "Disziplin",
+                "description": "Pflegemaßnahmen, die angemessenes Verhalten und Selbstkontrolle fördern."
+            },
+            "14": {
+                "title": "Verbandwechsel/Wundversorgung",
+                "description": "Tätigkeiten, die die Wundheilung fördern und Infektionen verhindern, wie z.B. das Beobachten, Messen, Reinigen, Spülen und/oder Abdecken einer Wunde, Läsion oder eines Einschnitts."
+            },
+            "15": {
+                "title": "Dauerhafte medizinische Geräte",
+                "description": "Nicht wegwerfbare Gegenstände, die bei der Pflege verwendet werden, wie Spezialbetten, Gehhilfen und Apnoe-Monitore."
+            },
+            "16": {
+                "title": "Bildung",
+                "description": "Formelle Programme, die eine allgemeine, technische oder individuelle Ausbildung für Schüler jeden Alters anbieten."
+            },
+            "17": {
+                "title": "Erwerbstätigkeit",
+                "description": "Berufstätigkeit, die das Einkommen sichert."
+            },
+            "18": {
+                "title": "Umwelt",
+                "description": "Physische Umgebung, Bedingungen oder Einflüsse am Wohnsitz, in der Nachbarschaft und/oder Gemeinde."
+            },
+            "19": {
+                "title": "Training",
+                "description": "Therapeutische, körperliche Aktivitäten (z.B. aktives/passives Training des Bewegungsradius, Isometrie, Dehnen, Gewichtheben)."
+            },
+            "20": {
+                "title": "Betreuung bei Familienplanung",
+                "description": "Maßnahmen, die Unterstützung bei der Auswahl und Anwendung von Methoden zur Vorbereitung auf eine Schwangerschaft und zur Schwangerschaftsvorsorge bieten."
+            },
+            "21": {
+                "title": "Unterstützung bei der Nahrungsaufnahme",
+                "description": "Verabreichung von Nahrung und Flüssigkeit (z.B. mittels Brust, Löffel, Sonde, intravenöser Lösung, in Form von Muttermilchersatz)."
+            },
+            "22": {
+                "title": "Finanzen",
+                "description": "Verwaltung von Einnahmen und Ausgaben."
+            },
+            "24": {
+                "title": "Gehübungen",
+                "description": "Systematische Aktivitäten, die das Gehen mit oder ohne Hilfsmittel fördern."
+            },
+            "25": {
+                "title": "Wachstums-/Entwicklungsförderung",
+                "description": "Maßnahmen, die die altersgerechte Entwicklung, gemessen am Gewicht, der Größe und dem Kopfumfang, und die Erreichung von Entwicklungsstufen fördern."
+            },
+            "27": {
+                "title": "Zuhause",
+                "description": "Wohnort."
+            },
+            "28": {
+                "title": "Interaktion",
+                "description": "Gegenseitiges Handeln oder gegenseitige Beeinflussung von Menschen wie Eltern-Kind, Eltern-Lehrer und Pflegekraft-Klient."
+            },
+            "29": {
+                "title": "Laborbefunde",
+                "description": "Ergebnisse von Flüssigkeits- und Gewebetests wie Urin- und Blutanalysen."
+            },
+            "30": {
+                "title": "Rechtssystem",
+                "description": "Behörden, Verhaltensrichtlinien oder Rechtsprechung."
+            },
+            "31": {
+                "title": "Medizinische/zahnärztliche Versorgung",
+                "description": "Einschätzung/Diagnosestellung und Behandlung durch Ärzte, Zahnärzte und deren Mitarbeiter oder Assistenten."
+            },
+            "32": {
+                "title": "Medikamentenwirkung/Nebenwirkungen",
+                "description": "Positive/negative Folgen von Medikamenten."
+            },
+            "33": {
+                "title": "Medikamente verabreichen",
+                "description": "Anwendung oder Verabreichung der Medikation, die von Klienten, Eltern/Betreuern oder medizinischen Fachkräften durchgeführt wird."
+            },
+            "34": {
+                "title": "Medikamente richten",
+                "description": "Vorbereitung der Medikamentenverabreichung durch Befüllen/Überprüfen eines Medikamentendosierers, Aufziehen von Spritzen oder Anlegen von intravenösen Zugängen."
+            },
+            "35": {
+                "title": "Mobilität/Bewegung",
+                "description": "Körperbewegungen, die die Position verändern oder die Teilnahme an Aktivitäten ermöglichen (z.B. Gehen)."
+            },
+            "38": {
+                "title": "Ernährungsberatung",
+                "description": "Einschätzung/Diagnosestellung und Betreuung durch Ernährungsberater und deren Personal oder Assistenten."
+            },
+            "39": {
+                "title": "Stomapflege oder Stomaversorgung",
+                "description": "Maßnahmen, die die Ausscheidung von Urin oder Stuhl über eine künstliche Öffnung steuern (z.B. Kolostomie, Ileostomie, Urostomie)."
+            },
+            "40": {
+                "title": "Sonstige soziale Einrichtungen",
+                "description": "Organisationen oder Gruppen, die Güter oder Dienstleistungen anbieten, welche nicht von anderen Maßnahmen adressiert werden (z.B. Trainingseinrichtungen, Lebensmittelausgaben, Glaubensgemeinschaften)."
+            },
+            "41": {
+                "title": "Körperhygiene",
+                "description": "Individuelle Pflegemaßnahmen (z.B. Körperpflege, Haarwäsche, Toilettengang)."
+            },
+            "42": {
+                "title": "Positionierung",
+                "description": "Positionierung des Körpers zur Förderung von Komfort und Körperfunktionen."
+            },
+            "44": {
+                "title": "Entspannungs-/Atemtechniken",
+                "description": "Maßnahmen, die den Muskeltonus entspannen, eine beruhigende Wirkung herbeiführen und Energieressourcen wieder stärken (z.B. Atemübungen, geführte Imagination, Meditation, Massage)."
+            },
+            "45": {
+                "title": "Ruhe/Schlaf",
+                "description": "Periodischer Zustand der Ruhe und variierendes Bewusstsein."
+            },
+            "46": {
+                "title": "Sicherheit",
+                "description": "Die Abwesenheit von Risiken, Verletzungen oder Verlust."
+            },
+            "47": {
+                "title": "Screening-Verfahren",
+                "description": "Strategien der Evaluation, die dazu genutzt werden Risikofaktoren früh zu identifizieren, Krankheiten zeitnah zu diagnostizieren und Veränderungen/Fortschreiten anhaltend zu überwachen."
+            },
+            "48": {
+                "title": "Versorgung bei Krankheit/Verletzung",
+                "description": "Maßnahmen bei Krankheiten oder Unfällen (z.B. Maßnahmen der Ersten Hilfe oder die Messung der Körpertemperatur)."
+            },
+            "49": {
+                "title": "Psychische/emotionale Symptome",
+                "description": "Objektiver oder subjektiver Nachweis von psychischen/emotionalen Gesundheitsproblemen (z.B. Depression, Verwirrung, Agitation)."
+            },
+            "50": {
+                "title": "Körperliche Symptome",
+                "description": "Objektiver oder subjektiver Nachweis von körperlichen Gesundheitsproblemen (z.B. Fieber, plötzlicher Gewichtsverlust, Schmerzäußerung)."
+            },
+            "51": {
+                "title": "Hautpflege",
+                "description": "Maßnahmen, die die Hautintegrität fördern (z.B. das Auftragen einer Lotion, Massagen)."
+            },
+            "52": {
+                "title": "Sozialarbeit/Beratung",
+                "description": "Einschätzung/Diagnosestellung und Betreuung durch Sozialarbeiter, Berater, Seelsorger und deren Mitarbeiter oder Assistenten."
+            },
+            "53": {
+                "title": "Probenentnahme",
+                "description": "Maßnahmen zur Gewinnung menschlicher oder tierischer Gewebe, Flüssigkeiten, Sekrete oder Ausscheidungen (z.B. Blut, Urin, Stuhl, Sputum, Drainage)."
+            },
+            "54": {
+                "title": "Seelische und spirituelle Begleitung",
+                "description": "Maßnahmen, die persönliche Gelassenheit und Trost fördern und dabei spirituelle Belange/Praktiken einbeziehen."
+            },
+            "55": {
+                "title": "Förderung/Zuwendung",
+                "description": "Aktivitäten, die eine gesunde körperliche, intellektuelle und emotionale Entwicklung fördern."
+            },
+            "56": {
+                "title": "Stressbewältigung",
+                "description": "Kognitive, emotionale und körperliche Aktivitäten, die die Gesundheit unter schwierigen Lebensbedingungen fördern."
+            },
+            "58": {
+                "title": "Hilfsmittel",
+                "description": "Einwegartikel, die während der Versorgung verwendet werden (z.B.: Verbandsmaterial, Spritzen, Schlauchsysteme, Inkontinenzmaterial, Babyflaschen)."
+            },
+            "59": {
+                "title": "Selbsthilfegruppe/Unterstützungsangebote",
+                "description": "Strukturierte Informations- und Unterstützungsangebote wie themenspezifische Gruppen, Kurse und Organisationen, Telefonseelsorge und zuverlässige Internetseiten, die sich mit einem bestimmen Thema befassen (z.B. Erziehung, Alkoholismus, Adipositas, Alzheimer)."
+            },
+            "60": {
+                "title": "Unterstützungssystem",
+                "description": "Ein Kreis von Familienmitgliedern, Freunden und Vertrauten, die Liebe, Fürsorge und Unterstützung bieten, um die Gesundheit zu fördern und Krankheit zu bewältigen."
+            },
+            "61": {
+                "title": "Fortbewegung",
+                "description": "Möglichkeiten der Fortbewegung (z.B. Auto, Bus, Taxi, Roller, Elektromobil)."
+            },
+            "62": {
+                "title": "Wohlergehen",
+                "description": "Maßnahmen, die die körperliche und geistige Gesundheit fördern (z.B. Bewegung, Ernährung, Immunisierung)."
+            },
+            "63": {
+                "title": "Sonstige",
+                "description": "Personen, Orte, Gegenstände oder Maßnahmen, die in dieser Liste nicht aufgeführt sind."
+            },
+            "64": {
+                "title": "Aggressionsbewältigung",
+                "description": "Maßnahmen, die negative Gefühle und Interaktionen, einschließlich Gewalt, verringern oder kontrollieren."
+            },
+            "65": {
+                "title": "Aufsuchende kommunale Dienste ",
+                "description": "Unterstützung bei der Koordination von Aufgaben in den Bereichen Gesundheitversorgung, Mobilität, Haushalt und Betreuung von Kindern/Erwachsenen durch qualifizierte Mitarbeiter unter der Supervision von Gesundheitsfachpersonen."
+            },
+            "66": {
+                "title": "Kontinuität der Versorgung",
+                "description": "Austausch von Informationen zwischen Anbietern/Organisationen, um eine sichere und effektive Versorgung zu gewährleisten und doppelte Arbeit zu vermeiden."
+            },
+            "67": {
+                "title": "Ernährungsmanagement",
+                "description": "Ernährung mit ausgewogenen Lebensmitteln und Flüssigkeiten, die lebensnotwendig sind, Energie liefern, sowie Wachstum und Gesundheit fördern."
+            },
+            "68": {
+                "title": "Versorgung am Lebensende",
+                "description": "Maßnahmen, die körperliches Wohlbefinden und emotionalen Ausgleich für Sterbende ermöglichen unter Einbeziehung/Berücksichtigung von Familie, Freunden, spirituellen Anliegen, Ritualen, Schmerzlinderung und Körperpflege."
+            },
+            "69": {
+                "title": "Genetik",
+                "description": "Diagnose, Beratung und Methoden zur Vorbeugung, Erkennung oder Behandlung von Geburtsfehlern, angeborenen Anomalien oder Einschränkungen."
+            },
+            "70": {
+                "title": "Haushaltsführung/Hauswirtschaft",
+                "description": "Management von z.B. Putzen, Wäsche waschen und Essenszubereitung zu Hause oder in einer Gesundheitseinrichtung."
+            },
+            "71": {
+                "title": "Infektionsschutzmaßnahmen",
+                "description": "Maßnahmen, die das Auftreten und die Übertragung ansteckender Krankheiten verringern (z.B. Händewaschen, Isolation, Probenentnahme, Kontaktnachverfolgung, Meldeverfahren, Umgebungskontrolle)."
+            },
+            "72": {
+                "title": "Dolmetscher-/Übersetzungsdienste",
+                "description": "Unterstützung bei der mündlichen oder schriftlichen Kommunikation in anderen Sprachen durch qualifizierte Mitarbeiter, unter Supervision von Gesundheitsfachkräften."
+            },
+            "73": {
+                "title": "Bestellung/Koordination der Medikation",
+                "description": "Kommunikation mit denjenigen, die Medikamente verschreiben und ausgeben, und den individuellen/familiären/kommunalen Unterstützungssystemen, um sicherzustellen, dass geeignete Medikamente und Hilfsmittel rechtzeitig beschafft werden."
+            },
+            "74": {
+                "title": "Verschreibung von Medikamenten",
+                "description": "Eine formalisierte pharmazeutische Bestellung/offizielle Anfrage für Medikamente."
+            },
+            "75": {
+                "title": "Pflege",
+                "description": "Beurteilung/Diagnosestellung und Behandlung durch Pflegefachkräfte und deren Personal oder Assistenten."
+            },
+            "76": {
+                "title": "Ergotherapie",
+                "description": "Einschätzung/Diagnosestellung und Behandlung durch Ergotherapeuten und deren Personal oder Assistenten."
+            },
+            "77": {
+                "title": "Versorgung durch Assistenzkräfte/Pflegehilfskräfte",
+                "description": "Unterstützung durch Assistenzkräfte und Pflegehilfskräfte unter der Supervision von Gesundheitsfachkräften."
+            },
+            "78": {
+                "title": "Physiotherapie",
+                "description": "Einschätzung/Diagnosestellung und Behandlung durch Physiotherapeuten und deren Personal oder Assistenten."
+            },
+            "79": {
+                "title": "Freizeittherapie/Alltagsbegleitung",
+                "description": "Einschätzung/Diagnosestellung und Betreuung durch Freizeittherapeuten/Alltagsbegleiter und deren Personal oder Assistenten."
+            },
+            "80": {
+                "title": "Unterstützung der Atmung",
+                "description": "Maßnahmen, die die Atmungs- oder Lungenfunktion fördern (z.B. Absaugen, Inhalation)"
+            },
+            "81": {
+                "title": "Atemtherapie",
+                "description": "Einschätzung/Diagnosestellung und Behandlung durch Atemtherapeuten und deren Personal oder Assistenten."
+            },
+            "82": {
+                "title": "Logopädie",
+                "description": "Einschätzung/Diagnosestellung und Behandlung durch Logopäden und deren Mitarbeiter oder Assistenten."
+            },
+            "83": {
+                "title": "Entwöhnung vom Drogenkonsum",
+                "description": "Maßnahmen, die die Entwöhnung von schädlichen/abhängig machenden Substanzen fördern."
+            },
+            "01": {
+                "title": "Anatomie/Physiologie",
+                "description": "Aufbau und Funktion des menschlichen Körpers."
+            },
+            "02": {
+                "title": "Verhaltensänderung",
+                "description": "Maßnahmen, die Gewohnheiten, Verhaltensweisen oder Handlungsmuster verändern."
+            },
+            "03": {
+                "title": "Blasenpflege",
+                "description": "Maßnahmen, die die Funktion der Harnblase fördern (z.B. Blasentraining, Katheterwechsel, Katheterspülung)."
+            },
+            "04": {
+                "title": "Bindung/Verbundenheit",
+                "description": "Eine gegenseitige, positive Beziehung zwischen zwei Personen (z.B. Elternteil/Erziehungsberechtigter und Säugling/Kind)."
+            },
+            "05": {
+                "title": "Darmpflege",
+                "description": "Maßnahmen, die die Darmfunktion fördern (z.B. Darmtraining, Einläufe)."
+            },
+            "07": {
+                "title": "Förderung des Herz-/Kreislaufsystems",
+                "description": "Maßnahmen, die die Herz- oder Kreislauffunktion fördern (z.B. Energieeinsparung, ausgeglichener Flüssigkeitshaushalt)."
+            },
+            "08": {
+                "title": "Fürsorge-/Erziehungskompetenz",
+                "description": "Tätigkeiten zur Versorgung familienangehöriger/abhängiger Kinder oder Erwachsener (z.B. Füttern/Nahrungsaufnahme, Baden/Körperpflege, Erziehung, Zuwendung, Förderung)."
+            },
+            "09": {
+                "title": "Gipsversorgung",
+                "description": "Maßnahmen, die ein verletztes Körperteil, welches durch einen Gips, eine Schiene oder eine andere Vorrichtung ruhig gestellt wird, sauber und trocken halten, stützen und ausrichten, sowie Schmerzen, Druckstellen und Einschnürungen verhindern."
+            }
+        }
+    },
+    "problemRatingScale": {
+        "title": "Problembewertungsskala",
+        "ratings": {
+            "0": {
+                "title": "Wissen",
+                "description": "Fähigkeit des Klienten, sich an Wissen zu erinnern und es zu interpretieren.",
+                "scale": {
+                    "0": {
+                        "title": "Kein Wissen"
+                    },
+                    "1": {
+                        "title": "Geringfügiges Wissen"
+                    },
+                    "2": {
+                        "title": "Grundlegendes Wissen"
+                    },
+                    "3": {
+                        "title": "Angemessenes Wissen"
+                    },
+                    "4": {
+                        "title": "Herausragendes Wissen"
+                    }
+                }
+            },
+            "1": {
+                "title": "Verhalten",
+                "description": "Beobachtbare Reaktionen, Handlungen oder Aktivitäten des Klienten, die dem Anlass oder Zweck entsprechen.",
+                "scale": {
+                    "0": {
+                        "title": "Nicht angemessenes Verhalten"
+                    },
+                    "1": {
+                        "title": "Selten angemessenes Verhalten"
+                    },
+                    "2": {
+                        "title": "Teilweise angemessenes Verhalten"
+                    },
+                    "3": {
+                        "title": "Meistens angemessenes Verhalten"
+                    },
+                    "4": {
+                        "title": "Durchgehend angemessenes Verhalten"
+                    }
+                }
+            },
+            "2": {
+                "title": "Zustand",
+                "description": "Verfassung des Klienten hinsichtlich objektiv und subjektiv bestimmender Symptome.",
+                "scale": {
+                    "0": {
+                        "title": "Extreme Symptome"
+                    },
+                    "1": {
+                        "title": "Schwerwiegende Symptome"
+                    },
+                    "2": {
+                        "title": "Mäßige Symptome"
+                    },
+                    "3": {
+                        "title": "Geringfügige Symptome"
+                    },
+                    "4": {
+                        "title": "Keine Symptome"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/public/terminology_EN.json
+++ b/public/terminology_EN.json
@@ -1,0 +1,1840 @@
+{
+    "title": "The Omaha System",
+    "problemClassificationScheme": {
+        "title": "Problem Classification Scheme",
+        "domains": {
+            "01": {
+                "title": "Environmental Domain",
+                "description": "Material resources and physical surroundings both inside and outside the living area, neighborhood, and broader community.",
+                "problems": {
+                    "01": {
+                        "title": "Income",
+                        "description": "Money from wages, pensions, subsidies, interest, dividends, or other sources available for living and health care expenses.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "low/no income"
+                            },
+                            "02": {
+                                "title": "uninsured medical expenses"
+                            },
+                            "03": {
+                                "title": "difficulty with money management"
+                            },
+                            "04": {
+                                "title": "able to buy only necessities"
+                            },
+                            "05": {
+                                "title": "difficulty buying necessities"
+                            },
+                            "06": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "02": {
+                        "title": "Sanitation",
+                        "description": "Environmental cleanliness and precautions against infection and disease.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "other"
+                            },
+                            "11": {
+                                "title": "presence of mold"
+                            },
+                            "12": {
+                                "title": "excessive pets"
+                            },
+                            "01": {
+                                "title": "soiled living area"
+                            },
+                            "02": {
+                                "title": "inadequate food storage/disposal"
+                            },
+                            "03": {
+                                "title": "insects/rodents"
+                            },
+                            "04": {
+                                "title": "foul odor"
+                            },
+                            "05": {
+                                "title": "inadequate water supply"
+                            },
+                            "06": {
+                                "title": "inadequate sewage disposal"
+                            },
+                            "07": {
+                                "title": "inadequate laundry facilities"
+                            },
+                            "08": {
+                                "title": "allergens"
+                            },
+                            "09": {
+                                "title": "infectious/contaminating agents"
+                            }
+                        }
+                    },
+                    "03": {
+                        "title": "Residence",
+                        "description": "Living area.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "unsafe appliances/equipment"
+                            },
+                            "11": {
+                                "title": "inadequate/crowded living space"
+                            },
+                            "12": {
+                                "title": "homeless"
+                            },
+                            "13": {
+                                "title": "other"
+                            },
+                            "14": {
+                                "title": "exposed wiring"
+                            },
+                            "15": {
+                                "title": "structural barriers"
+                            },
+                            "01": {
+                                "title": "structurally unsound"
+                            },
+                            "02": {
+                                "title": "inadequate heating/cooling"
+                            },
+                            "03": {
+                                "title": "steep/unsafe stairs"
+                            },
+                            "04": {
+                                "title": "inadequate/obstructed exits/entries"
+                            },
+                            "05": {
+                                "title": "cluttered living space"
+                            },
+                            "06": {
+                                "title": "unsafe storage of dangerous objects/substances"
+                            },
+                            "07": {
+                                "title": "unsafe mats/throw rugs"
+                            },
+                            "08": {
+                                "title": "inadequate safety devices"
+                            },
+                            "09": {
+                                "title": "presence of lead-based paint"
+                            }
+                        }
+                    },
+                    "04": {
+                        "title": "Neighborhood/workplace safety",
+                        "description": "Freedom from illness, injury, or loss in the community or place of employment.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "chemical hazards"
+                            },
+                            "11": {
+                                "title": "radiological hazards"
+                            },
+                            "01": {
+                                "title": "high crime rate"
+                            },
+                            "02": {
+                                "title": "high pollution level"
+                            },
+                            "03": {
+                                "title": "uncontrolled/dangerous/infected animals"
+                            },
+                            "05": {
+                                "title": "inadequate/unsafe play/exercise areas"
+                            },
+                            "07": {
+                                "title": "inadequate space/resources to foster health"
+                            },
+                            "08": {
+                                "title": "threats/reports of violence"
+                            },
+                            "04": {
+                                "title": "physical hazards"
+                            },
+                            "09": {
+                                "title": "vehicle/traffic hazards"
+                            },
+                            "06": {
+                                "title": "other"
+                            }
+                        }
+                    }
+                }
+            },
+            "02": {
+                "title": "Psychosocial Domain",
+                "description": "Patterns of behavior, emotion, communication, relationships, and development.",
+                "problems": {
+                    "10": {
+                        "title": "Spirituality",
+                        "description": "Beliefs and practices that involve faith, religion, values, the spirit, and/or the soul.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "expresses spiritual concerns"
+                            },
+                            "02": {
+                                "title": "disrupted spiritual rituals"
+                            },
+                            "03": {
+                                "title": "disrupted spiritual trust"
+                            },
+                            "04": {
+                                "title": "conflicting spiritual beliefs and medical/health care regimen"
+                            },
+                            "05": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "11": {
+                        "title": "Grief",
+                        "description": "Suffering and distress associated with loss.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "fails to recognize stages of grief/process of healing"
+                            },
+                            "02": {
+                                "title": "difficulty coping with grief responses"
+                            },
+                            "03": {
+                                "title": "difficulty expressing grief responses"
+                            },
+                            "04": {
+                                "title": "conflicting stages of grief among individuals/families"
+                            },
+                            "05": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "12": {
+                        "title": "Mental health",
+                        "description": "Development and use of mental/emotional abilities to adjust to life situations, interact with others, and engage in activities",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "somatic complaints/fatigue"
+                            },
+                            "12": {
+                                "title": "other"
+                            },
+                            "13": {
+                                "title": "narrowed to scattered attention/focus"
+                            },
+                            "14": {
+                                "title": "irritable/agitated/aggressive"
+                            },
+                            "15": {
+                                "title": "purposeless/compulsive activity"
+                            },
+                            "16": {
+                                "title": "difficulty managing anger"
+                            },
+                            "17": {
+                                "title": "delusions"
+                            },
+                            "18": {
+                                "title": "hallucinations/illusions"
+                            },
+                            "19": {
+                                "title": "expresses suicidal/homicidal thoughts"
+                            },
+                            "20": {
+                                "title": "attempts suicide/homicide"
+                            },
+                            "21": {
+                                "title": "self-mutilation"
+                            },
+                            "22": {
+                                "title": "mood swings"
+                            },
+                            "23": {
+                                "title": "flash-backs"
+                            },
+                            "01": {
+                                "title": "sadness/hopelessness/decreased self-esteem"
+                            },
+                            "02": {
+                                "title": "apprehension/undefined fear"
+                            },
+                            "03": {
+                                "title": "loss of interest/involvement in activities/self-care"
+                            },
+                            "06": {
+                                "title": "flat affect"
+                            },
+                            "09": {
+                                "title": "difficulty managing stress"
+                            }
+                        }
+                    },
+                    "13": {
+                        "title": "Sexuality",
+                        "description": "Attitudes, feelings, and behaviors related to intimacy and sexual activity.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "difficulty recognizing consequences of sexual behavior"
+                            },
+                            "02": {
+                                "title": "difficulty expressing intimacy"
+                            },
+                            "03": {
+                                "title": "sexual identity confusion"
+                            },
+                            "04": {
+                                "title": "sexual value confusion"
+                            },
+                            "05": {
+                                "title": "dissatisfied with sexual relationships"
+                            },
+                            "07": {
+                                "title": "unsafe sexual practices"
+                            },
+                            "08": {
+                                "title": "sexual acting out/provocative behaviors/harassment"
+                            },
+                            "09": {
+                                "title": "sexual perpetration/assault"
+                            },
+                            "06": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "14": {
+                        "title": "Caretaking/parenting",
+                        "description": "Providing support, nurturance, stimulation, and physical care for dependent child or adult.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "difficulty interpreting or responding to verbal/nonverbal communication"
+                            },
+                            "01": {
+                                "title": "difficulty providing physical care/safety"
+                            },
+                            "02": {
+                                "title": "difficulty providing emotional nurturance"
+                            },
+                            "03": {
+                                "title": "difficulty providing cognitive learning experiences and activities"
+                            },
+                            "04": {
+                                "title": "difficulty providing preventive and therapeutic health care"
+                            },
+                            "05": {
+                                "title": "expectations incongruent with stage of growth and development"
+                            },
+                            "06": {
+                                "title": "dissatisfaction/difficulty with responsibilities"
+                            },
+                            "07": {
+                                "title": "neglectful"
+                            },
+                            "08": {
+                                "title": "abusive"
+                            },
+                            "09": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "15": {
+                        "title": "Neglect",
+                        "description": "Child or adult deprived of minimally accepted standards of food, shelter, clothing, or care.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "lacks adequate physical care"
+                            },
+                            "02": {
+                                "title": "lacks emotional nurturance/support"
+                            },
+                            "03": {
+                                "title": "lacks appropriate stimulation/cognitive experiences"
+                            },
+                            "04": {
+                                "title": "inappropriately left alone"
+                            },
+                            "05": {
+                                "title": "lacks necessary supervision"
+                            },
+                            "06": {
+                                "title": "inadequate/delayed medical care"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "16": {
+                        "title": "Abuse",
+                        "description": "Child or adult subjected to nonaccidental physical, emotional, or sexual violence or injury.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "harsh/excessive discipline"
+                            },
+                            "02": {
+                                "title": "welts/burns/other injuries"
+                            },
+                            "03": {
+                                "title": "questionable explanation of injury"
+                            },
+                            "04": {
+                                "title": "attacked verbally"
+                            },
+                            "05": {
+                                "title": "fearful/hypervigilant behavior"
+                            },
+                            "06": {
+                                "title": "violent environment"
+                            },
+                            "07": {
+                                "title": "consistent negative messages"
+                            },
+                            "08": {
+                                "title": "assaulted sexually"
+                            },
+                            "09": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "17": {
+                        "title": "Growth & development",
+                        "description": "Progressive physical, emotional, and social maturation along the age continuum from birth to death.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "abnormal results of developmental screening tests"
+                            },
+                            "02": {
+                                "title": "abnormal weight/height/head circumference in relation to growth/aging standards"
+                            },
+                            "03": {
+                                "title": "age-inappropriate behavior"
+                            },
+                            "04": {
+                                "title": "inadequate achievement/maintenance of developmental tasks"
+                            },
+                            "05": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "06": {
+                        "title": "Communication with community resources",
+                        "description": "Interaction between the individual/family/community and social service organizations, schools, and businesses in regard to services, information, and goods/supplies.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "transportation barrier"
+                            },
+                            "11": {
+                                "title": "limited access to care/services/goods"
+                            },
+                            "12": {
+                                "title": "unable to use/has inadequate communication devices/equipment"
+                            },
+                            "01": {
+                                "title": "unfamiliar with options/procedures for obtaining services"
+                            },
+                            "02": {
+                                "title": "difficulty understanding roles/regulations of service providers"
+                            },
+                            "03": {
+                                "title": "unable to communicate concerns to provider"
+                            },
+                            "04": {
+                                "title": "dissatisfaction with services"
+                            },
+                            "06": {
+                                "title": "inadequate/unavailable resources"
+                            },
+                            "05": {
+                                "title": "language barrier"
+                            },
+                            "08": {
+                                "title": "cultural barrier"
+                            },
+                            "09": {
+                                "title": "educational barrier"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "07": {
+                        "title": "Social contact",
+                        "description": "Interaction between the individual/family/community and others outside the immediate living area.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "limited social contact"
+                            },
+                            "02": {
+                                "title": "uses health care provider for social contact"
+                            },
+                            "03": {
+                                "title": "minimal outside stimulation/leisure time activities"
+                            },
+                            "04": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "08": {
+                        "title": "Role change",
+                        "description": "Additions to or removal of a set of expected behavioral characteristics.",
+                        "signsAndSymptoms": {
+                            "06": {
+                                "title": "involuntary role reversal"
+                            },
+                            "03": {
+                                "title": "assumes new role"
+                            },
+                            "04": {
+                                "title": "loses previous role"
+                            },
+                            "05": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "09": {
+                        "title": "Interpersonal relationship",
+                        "description": "Associations or bonds between the individual/family/community and others.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "difficulty problem solving without conflict"
+                            },
+                            "01": {
+                                "title": "difficulty establishing/maintaining relationships"
+                            },
+                            "02": {
+                                "title": "minimal shared activities"
+                            },
+                            "03": {
+                                "title": "incongruent values/goals/expectations/schedules"
+                            },
+                            "04": {
+                                "title": "inadequate interpersonal communication skills"
+                            },
+                            "05": {
+                                "title": "prolonged, unrelieved tension"
+                            },
+                            "08": {
+                                "title": "inappropriate suspicion/manipulation/control"
+                            },
+                            "09": {
+                                "title": "physically/emotionally abusive to partner"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    }
+                }
+            },
+            "03": {
+                "title": "Physiological Domain",
+                "description": "Functions and processes that maintain life.",
+                "problems": {
+                    "19": {
+                        "title": "Hearing",
+                        "description": "Perception of sound by the ears.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "difficulty hearing normal speech tones"
+                            },
+                            "05": {
+                                "title": "difficulty hearing speech in large group settings"
+                            },
+                            "06": {
+                                "title": "difficulty hearing high frequency sounds"
+                            },
+                            "02": {
+                                "title": "absent/abnormal response to sound"
+                            },
+                            "03": {
+                                "title": "abnormal results of hearing screening test"
+                            },
+                            "04": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "20": {
+                        "title": "Vision",
+                        "description": "Act or power of sensing with the eyes.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "difficulty seeing small print/calibrations"
+                            },
+                            "02": {
+                                "title": "difficulty seeing distant objects"
+                            },
+                            "03": {
+                                "title": "difficulty seeing close objects"
+                            },
+                            "04": {
+                                "title": "absent/abnormal response to visual stimuli"
+                            },
+                            "05": {
+                                "title": "abnormal results of vision screening test"
+                            },
+                            "06": {
+                                "title": "squinting/blinking/tearing/blurring"
+                            },
+                            "09": {
+                                "title": "floaters/flashes"
+                            },
+                            "07": {
+                                "title": "difficulty differentiating colors"
+                            },
+                            "08": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "21": {
+                        "title": "Speech & language",
+                        "description": "Use of articulated vocal sounds, symbols, signs, or gestures for communication.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "absent/abnormal ability to speak/vocalize"
+                            },
+                            "02": {
+                                "title": "absent/abnormal ability to understand"
+                            },
+                            "03": {
+                                "title": "lacks alternative communication skills/gestures"
+                            },
+                            "04": {
+                                "title": "inappropriate sentence structure"
+                            },
+                            "05": {
+                                "title": "limited enunciation/clarity"
+                            },
+                            "06": {
+                                "title": "inappropriate word usage"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "23": {
+                        "title": "Cognition",
+                        "description": "Ability to think and use information.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "other"
+                            },
+                            "11": {
+                                "title": "wanders"
+                            },
+                            "01": {
+                                "title": "diminished judgment"
+                            },
+                            "02": {
+                                "title": "disoriented to time/place/person"
+                            },
+                            "03": {
+                                "title": "limited recall of recent events"
+                            },
+                            "04": {
+                                "title": "limited recall of long past events"
+                            },
+                            "05": {
+                                "title": "limited calculating/sequencing skills"
+                            },
+                            "06": {
+                                "title": "limited concentration"
+                            },
+                            "07": {
+                                "title": "limited reasoning/abstract thinking ability"
+                            },
+                            "08": {
+                                "title": "impulsiveness"
+                            },
+                            "09": {
+                                "title": "repetitious language/behavior"
+                            }
+                        }
+                    },
+                    "24": {
+                        "title": "Pain",
+                        "description": "Unpleasant sensory and emotional experience associated with actual or potential tissue damage.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "expresses discomfort/pain"
+                            },
+                            "02": {
+                                "title": "elevated pulse/respirations/blood pressure"
+                            },
+                            "03": {
+                                "title": "compensated movement/guarding"
+                            },
+                            "04": {
+                                "title": "restless behavior"
+                            },
+                            "05": {
+                                "title": "facial grimaces"
+                            },
+                            "06": {
+                                "title": "pallor/perspiration"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "25": {
+                        "title": "Consciousness",
+                        "description": "Awareness of and responsiveness to stimuli and the surroundings.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "lethargic"
+                            },
+                            "02": {
+                                "title": "stuporous"
+                            },
+                            "03": {
+                                "title": "unresponsive"
+                            },
+                            "04": {
+                                "title": "comatose"
+                            },
+                            "05": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "26": {
+                        "title": "Skin",
+                        "description": "Natural covering of the body.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "other"
+                            },
+                            "11": {
+                                "title": "delayed incisional healing"
+                            },
+                            "01": {
+                                "title": "lesion/pressure ulcer"
+                            },
+                            "02": {
+                                "title": "rash"
+                            },
+                            "03": {
+                                "title": "excessively dry"
+                            },
+                            "04": {
+                                "title": "excessively oily"
+                            },
+                            "05": {
+                                "title": "inflammation"
+                            },
+                            "06": {
+                                "title": "pruritus"
+                            },
+                            "07": {
+                                "title": "drainage"
+                            },
+                            "08": {
+                                "title": "bruising"
+                            },
+                            "09": {
+                                "title": "hypertrophy of nails"
+                            }
+                        }
+                    },
+                    "27": {
+                        "title": "Neuro-musculo-skeletal function",
+                        "description": "Ability of nerves, muscles, and bones to perform or coordinate specific movement, sensation, or regulation.",
+                        "signsAndSymptoms": {
+                            "11": {
+                                "title": "tremors/seizures"
+                            },
+                            "12": {
+                                "title": "other"
+                            },
+                            "13": {
+                                "title": "difficulty transferring"
+                            },
+                            "14": {
+                                "title": "fractures"
+                            },
+                            "15": {
+                                "title": "difficulty with thermoregulation"
+                            },
+                            "01": {
+                                "title": "limited range of motion"
+                            },
+                            "02": {
+                                "title": "decreased muscle strength"
+                            },
+                            "03": {
+                                "title": "decreased coordination"
+                            },
+                            "04": {
+                                "title": "decreased muscle tone"
+                            },
+                            "05": {
+                                "title": "increased muscle tone"
+                            },
+                            "06": {
+                                "title": "decreased sensation"
+                            },
+                            "07": {
+                                "title": "increased sensation"
+                            },
+                            "08": {
+                                "title": "decreased balance"
+                            },
+                            "09": {
+                                "title": "gait/ambulation disturbance"
+                            }
+                        }
+                    },
+                    "28": {
+                        "title": "Respiration",
+                        "description": "Inhaling and exhaling air into the body and exchanging oxygen.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "other"
+                            },
+                            "11": {
+                                "title": "abnormal respiratory laboratory results"
+                            },
+                            "01": {
+                                "title": "abnormal breath patterns"
+                            },
+                            "02": {
+                                "title": "unable to breathe independently"
+                            },
+                            "03": {
+                                "title": "cough"
+                            },
+                            "04": {
+                                "title": "unable to cough/expectorate independently"
+                            },
+                            "05": {
+                                "title": "cyanosis"
+                            },
+                            "06": {
+                                "title": "abnormal sputum"
+                            },
+                            "07": {
+                                "title": "noisy respirations"
+                            },
+                            "08": {
+                                "title": "rhinorrhea/nasal congestion"
+                            },
+                            "09": {
+                                "title": "abnormal breath sounds"
+                            }
+                        }
+                    },
+                    "29": {
+                        "title": "Circulation",
+                        "description": "Pumping blood in adequate amounts and pressure throughout the body.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "irregular heart rate"
+                            },
+                            "11": {
+                                "title": "excessively rapid heart rate"
+                            },
+                            "12": {
+                                "title": "excessively slow heart rate"
+                            },
+                            "13": {
+                                "title": "anginal pain"
+                            },
+                            "14": {
+                                "title": "abnormal heart sounds/murmurs"
+                            },
+                            "15": {
+                                "title": "other"
+                            },
+                            "16": {
+                                "title": "abnormal clotting"
+                            },
+                            "17": {
+                                "title": "abnormal cardiac laboratory results"
+                            },
+                            "01": {
+                                "title": "edema"
+                            },
+                            "02": {
+                                "title": "cramping/pain of extremities"
+                            },
+                            "03": {
+                                "title": "decreased pulses"
+                            },
+                            "04": {
+                                "title": "discoloration of skin"
+                            },
+                            "05": {
+                                "title": "temperature change in affected area"
+                            },
+                            "06": {
+                                "title": "varicosities"
+                            },
+                            "07": {
+                                "title": "syncopal episodes (fainting)/dizziness"
+                            },
+                            "08": {
+                                "title": "abnormal blood pressure reading"
+                            },
+                            "09": {
+                                "title": "pulse deficit"
+                            }
+                        }
+                    },
+                    "30": {
+                        "title": "Digestion-hydration",
+                        "description": "Process of converting food into forms that can be absorbed and assimilated, and maintaining fluid balance.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "cracked lips/dry mouth"
+                            },
+                            "11": {
+                                "title": "electrolyte imbalance"
+                            },
+                            "12": {
+                                "title": "other"
+                            },
+                            "01": {
+                                "title": "nausea/vomiting"
+                            },
+                            "02": {
+                                "title": "difficulty/inability to chew/swallow/digest"
+                            },
+                            "03": {
+                                "title": "indigestion"
+                            },
+                            "04": {
+                                "title": "reflux"
+                            },
+                            "05": {
+                                "title": "anorexia"
+                            },
+                            "06": {
+                                "title": "anemia"
+                            },
+                            "07": {
+                                "title": "ascites"
+                            },
+                            "08": {
+                                "title": "jaundice/liver enlargement"
+                            },
+                            "09": {
+                                "title": "decreased skin turgor"
+                            }
+                        }
+                    },
+                    "31": {
+                        "title": "Bowel function",
+                        "description": "Transporting food through the gastrointestinal tract to eliminate wastes.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "abnormal frequency/consistency of stool"
+                            },
+                            "02": {
+                                "title": "painful defecation"
+                            },
+                            "03": {
+                                "title": "decreased bowel sounds"
+                            },
+                            "04": {
+                                "title": "blood in stools"
+                            },
+                            "05": {
+                                "title": "abnormal color"
+                            },
+                            "06": {
+                                "title": "cramping/abdominal discomfort"
+                            },
+                            "07": {
+                                "title": "incontinent of stool"
+                            },
+                            "08": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "45": {
+                        "title": "Oral health",
+                        "description": "Condition of the mouth and gums and the number, type, and arrangement of the teeth.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "missing/broken/malformed teeth"
+                            },
+                            "02": {
+                                "title": "caries"
+                            },
+                            "03": {
+                                "title": "excess tartar"
+                            },
+                            "04": {
+                                "title": "sore/swollen/bleeding gums"
+                            },
+                            "05": {
+                                "title": "malocclusion"
+                            },
+                            "06": {
+                                "title": "ill-fitting/missing dentures"
+                            },
+                            "07": {
+                                "title": "sensitivity to hot or cold"
+                            },
+                            "08": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "46": {
+                        "title": "Urinary function",
+                        "description": "Production and excretion of urine.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "other"
+                            },
+                            "01": {
+                                "title": "burning/painful urination"
+                            },
+                            "02": {
+                                "title": "incontinent of urine"
+                            },
+                            "03": {
+                                "title": "urgency/frequency"
+                            },
+                            "04": {
+                                "title": "difficulty initiating urination"
+                            },
+                            "05": {
+                                "title": "difficulty emptying bladder"
+                            },
+                            "06": {
+                                "title": "abnormal amount"
+                            },
+                            "07": {
+                                "title": "hematuria/abnormal color"
+                            },
+                            "08": {
+                                "title": "nocturia"
+                            },
+                            "09": {
+                                "title": "abnormal urinary laboratory results"
+                            }
+                        }
+                    },
+                    "47": {
+                        "title": "Reproductive function",
+                        "description": "Condition of the genital organs and breasts and the ability to reproduce.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "abnormal discharge"
+                            },
+                            "02": {
+                                "title": "abnormal menstrual pattern"
+                            },
+                            "03": {
+                                "title": "difficulty managing menopause/andropause"
+                            },
+                            "04": {
+                                "title": "abnormal lumps/swelling/tenderness of genital organs or breasts"
+                            },
+                            "05": {
+                                "title": "pain during or after sexual intercourse"
+                            },
+                            "06": {
+                                "title": "infertility"
+                            },
+                            "07": {
+                                "title": "impotency"
+                            },
+                            "08": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "48": {
+                        "title": "Pregnancy",
+                        "description": "Period from conception to childbirth.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "difficulty bonding with unborn baby"
+                            },
+                            "02": {
+                                "title": "difficulty coping with body changes"
+                            },
+                            "03": {
+                                "title": "difficulty with prenatal exercise/rest/diet/behaviors"
+                            },
+                            "04": {
+                                "title": "fears delivery procedure"
+                            },
+                            "05": {
+                                "title": "prenatal complications/preterm labor"
+                            },
+                            "06": {
+                                "title": "inadequate social support"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "49": {
+                        "title": "Postpartum",
+                        "description": "Six-week period following childbirth.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "difficulty breast-feeding"
+                            },
+                            "02": {
+                                "title": "difficulty coping with postpartum changes"
+                            },
+                            "03": {
+                                "title": "difficulty with postpartum exercise/rest/diet/behaviors"
+                            },
+                            "04": {
+                                "title": "abnormal bleeding/vaginal discharge"
+                            },
+                            "05": {
+                                "title": "postpartum complications"
+                            },
+                            "06": {
+                                "title": "abnormal depressed feelings"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "50": {
+                        "title": "Communicable/infectious condition",
+                        "description": "State in which organisms invade/infest and produce superficial or systemic illness with the potential for spreading or transmission.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "infection"
+                            },
+                            "02": {
+                                "title": "infestation"
+                            },
+                            "03": {
+                                "title": "fever"
+                            },
+                            "04": {
+                                "title": "biological hazards"
+                            },
+                            "05": {
+                                "title": "positive screening/culture/laboratory results"
+                            },
+                            "06": {
+                                "title": "inadequate supplies/equipment/policies to prevent transmission"
+                            },
+                            "07": {
+                                "title": "does not follow infection control regimen"
+                            },
+                            "08": {
+                                "title": "inadequate immunity"
+                            },
+                            "09": {
+                                "title": "other"
+                            }
+                        }
+                    }
+                }
+            },
+            "04": {
+                "title": "Health-related Behaviors Domain",
+                "description": "Patterns of activity that maintain or promote wellness, promote recovery, and decrease the risk of disease.",
+                "problems": {
+                    "35": {
+                        "title": "Nutrition",
+                        "description": "Select, consume, and use food and fluids for energy, maintenance, growth, and health.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "hyperglycemia"
+                            },
+                            "11": {
+                                "title": "other"
+                            },
+                            "12": {
+                                "title": "overweight: adult BMI 25.0 or more; child BMI 95th percentile or more"
+                            },
+                            "13": {
+                                "title": "underweight: adult BMI 18.5 or less; child BMI 5th percentile or less"
+                            },
+                            "14": {
+                                "title": "unable to obtain/prepare food"
+                            },
+                            "03": {
+                                "title": "lacks established standards for daily caloric/fluid intake"
+                            },
+                            "04": {
+                                "title": "exceeds established standards for daily caloric/fluid intake"
+                            },
+                            "05": {
+                                "title": "unbalanced diet"
+                            },
+                            "06": {
+                                "title": "improper feeding schedule for age"
+                            },
+                            "07": {
+                                "title": "does not follow recommended nutrition plan"
+                            },
+                            "08": {
+                                "title": "unexplained/progressive weight loss"
+                            },
+                            "09": {
+                                "title": "hypoglycemia"
+                            }
+                        }
+                    },
+                    "36": {
+                        "title": "Sleep & rest patterns",
+                        "description": "Periods of suspended motor and sensory activity and periods of inactivity, repose, or mental calm.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "sleep/rest pattern disrupts family"
+                            },
+                            "02": {
+                                "title": "frequently wakes during night"
+                            },
+                            "03": {
+                                "title": "sleepwalking"
+                            },
+                            "04": {
+                                "title": "insomnia"
+                            },
+                            "05": {
+                                "title": "nightmares"
+                            },
+                            "06": {
+                                "title": "insufficient sleep/rest for age/physical condition"
+                            },
+                            "08": {
+                                "title": "sleep apnea"
+                            },
+                            "09": {
+                                "title": "snoring"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "37": {
+                        "title": "Physical activity",
+                        "description": "State or quality of body movements during daily living.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "sedentary life style"
+                            },
+                            "02": {
+                                "title": "inadequate/inconsistent exercise routine"
+                            },
+                            "03": {
+                                "title": "inappropriate type/amount of exercise for age/physical condition"
+                            },
+                            "04": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "38": {
+                        "title": "Personal care",
+                        "description": "Management of personal cleanliness and dressing.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "unwilling/unable/forgets to complete personal care activities"
+                            },
+                            "01": {
+                                "title": "difficulty laundering clothing"
+                            },
+                            "02": {
+                                "title": "difficulty with bathing"
+                            },
+                            "07": {
+                                "title": "difficulty with toileting activities"
+                            },
+                            "08": {
+                                "title": "difficulty dressing lower body"
+                            },
+                            "09": {
+                                "title": "difficulty dressing upper body"
+                            },
+                            "03": {
+                                "title": "foul body odor"
+                            },
+                            "04": {
+                                "title": "difficulty shampooing/combing hair"
+                            },
+                            "05": {
+                                "title": "difficulty brushing/flossing/mouth care"
+                            },
+                            "06": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "39": {
+                        "title": "Substance use",
+                        "description": "Consumption of medicines, recreational drugs, or other materials likely to cause mood changes and/or psychological/physical dependence, illness, and disease.",
+                        "signsAndSymptoms": {
+                            "10": {
+                                "title": "exposure to cigarette/cigar smoke"
+                            },
+                            "11": {
+                                "title": "buys/sells illegal substances"
+                            },
+                            "08": {
+                                "title": "abuses over-the-counter/prescription medications"
+                            },
+                            "09": {
+                                "title": "uses 'street' - recreational drugs"
+                            },
+                            "02": {
+                                "title": "abuses alcohol"
+                            },
+                            "03": {
+                                "title": "smokes/uses tobacco products"
+                            },
+                            "04": {
+                                "title": "difficulty performing normal routines"
+                            },
+                            "05": {
+                                "title": "reflex disturbances"
+                            },
+                            "06": {
+                                "title": "behavior change"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "40": {
+                        "title": "Family planning",
+                        "description": "Practices designed to plan and space pregnancy within the context of values, attitudes, and beliefs.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "inappropriate/insufficient knowledge about family planning methods"
+                            },
+                            "05": {
+                                "title": "inappropriate/insufficient knowledge about preconception health practices"
+                            },
+                            "02": {
+                                "title": "inaccurate/inconsistent use of family planning methods"
+                            },
+                            "03": {
+                                "title": "dissatisfied with present family planning method"
+                            },
+                            "06": {
+                                "title": "fears others' reactions regarding family planning choices"
+                            },
+                            "07": {
+                                "title": "difficulty obtaining family planning methods"
+                            },
+                            "04": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "41": {
+                        "title": "Health care supervision",
+                        "description": "Management of the health care treatment plan by health care providers.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "fails to obtain routine/preventive health care"
+                            },
+                            "02": {
+                                "title": "fails to seek care for symptoms requiring evaluation/treatment"
+                            },
+                            "03": {
+                                "title": "fails to return as requested to health care provider"
+                            },
+                            "04": {
+                                "title": "inability to coordinate multiple appointments/treatment plans"
+                            },
+                            "05": {
+                                "title": "inconsistent source of health care"
+                            },
+                            "08": {
+                                "title": "inadequate source of health care"
+                            },
+                            "06": {
+                                "title": "inadequate treatment plan"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    },
+                    "42": {
+                        "title": "Medication regimen",
+                        "description": "Use or application of over-the-counter and prescribed/recommended medications and infusions to meet guidelines for therapeutic action, safety, and schedule.",
+                        "signsAndSymptoms": {
+                            "01": {
+                                "title": "does not follow recommended dosage/schedule"
+                            },
+                            "02": {
+                                "title": "evidence of side effects/adverse reactions"
+                            },
+                            "03": {
+                                "title": "inadequate system for taking medication"
+                            },
+                            "04": {
+                                "title": "improper storage of medication"
+                            },
+                            "05": {
+                                "title": "fails to obtain refills appropriately"
+                            },
+                            "06": {
+                                "title": "fails to obtain immunizations"
+                            },
+                            "08": {
+                                "title": "inadequate medication regimen"
+                            },
+                            "09": {
+                                "title": "unable to take medications without help"
+                            },
+                            "07": {
+                                "title": "other"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "modifiers": {
+            "scope": {
+                "0": {
+                    "title": "Individual",
+                    "description": "A person who lives alone or a single-family member who experiences a health-related problem."
+                },
+                "1": {
+                    "title": "Family",
+                    "description": "A social unit or related group of individuals who live together and experience a health-related problem."
+                },
+                "2": {
+                    "title": "Community",
+                    "description": "The individuals and/or families who comprise a group, neighborhood, or other geographic district that experience a health-related problem."
+                }
+            },
+            "severity": {
+                "0": {
+                    "title": "Health Promotion",
+                    "description": "Client interest in increasing knowledge, behavior, and health expectations and developing more assets and resources that maintain or enhance well-being in the absence of risk factors, signs, or symptoms."
+                },
+                "1": {
+                    "title": "Potential",
+                    "description": "Client status characterized by the presence of certain health patterns, practices, behaviors, or risk factors that may preclude optimal health and the absence of signs and symptoms."
+                },
+                "2": {
+                    "title": "Actual",
+                    "description": "Client status characterized by one or more existing signs and symptoms that may preclude optimal health."
+                }
+            }
+        }
+    },
+    "interventionScheme": {
+        "title": "Intervention Scheme",
+        "categories": {
+            "01": {
+                "title": "Teaching, Guidance, and Counseling",
+                "description": "Activities designed to provide information and materials, encourage action and responsibility for self-care and coping, and assist the individual, family, or community to make decisions and solve problems."
+            },
+            "02": {
+                "title": "Treatments and Procedures",
+                "description": "Technical activities such as wound care, specimen collection, resistive exercises, and medication prescriptions that are designed to prevent, decrease, or alleviate signs and symptoms for the individual, family, or community."
+            },
+            "03": {
+                "title": "Case Management",
+                "description": "Activities such as coordination, advocacy, and referral that facilitate service delivery, promote assertiveness, guide the individual, family, or community toward use of appropriate resources, and improve communication among health and human service providers."
+            },
+            "04": {
+                "title": "Surveillance",
+                "description": "Activities such as detection, measurement, critical analysis, and monitoring intended to identify the individual, family, or community's status in relation to a given condition or phenomenon."
+            }
+        },
+        "targets": {
+            "10": {
+                "title": "communication",
+                "description": "Exchange of verbal or nonverbal information between the individual/family/community and others."
+            },
+            "11": {
+                "title": "coping skills",
+                "description": "Ability to effectively manage challenges and changes such as illness, disability, loss of income, birth of a child, or death of a family member."
+            },
+            "12": {
+                "title": "day care/respite",
+                "description": "Individuals or organizations that provide child/adult supervision while the parent/usual caregiver attends school, works, or has relief from usual responsibilities."
+            },
+            "13": {
+                "title": "discipline",
+                "description": "Nurturing practices that promote appropriate behavior, conduct, and self-control."
+            },
+            "14": {
+                "title": "dressing change/wound care",
+                "description": "Activities that promote wound healing and prevent infection such as observing, measuring, cleansing, irrigating, and/or covering a wound, lesion, or incision."
+            },
+            "15": {
+                "title": "durable medical equipment",
+                "description": "Nondisposable items used while providing care such as special beds, walkers, and apnea monitors."
+            },
+            "16": {
+                "title": "education",
+                "description": "Formal programs that offer general, technical, or individualized studies for students of all ages."
+            },
+            "17": {
+                "title": "employment",
+                "description": "Occupation that provides income."
+            },
+            "18": {
+                "title": "environment",
+                "description": "Physical surroundings, conditions, or influences in the residence, neighborhood, and/or community"
+            },
+            "19": {
+                "title": "exercises",
+                "description": "Therapeutic physical activities such as active/passive range of motion, isometrics, stretching, and weight lifting."
+            },
+            "20": {
+                "title": "family planning care",
+                "description": "Activities that support consideration and use of methods to prepare for and space pregnancy."
+            },
+            "21": {
+                "title": "feeding procedures",
+                "description": "Provision of food or fluids using methods such as breast, formula, spoon, tube, and intravenous solutions."
+            },
+            "22": {
+                "title": "finances",
+                "description": "Management of income and expenses."
+            },
+            "24": {
+                "title": "gait training",
+                "description": "Systematic activities that promote walking with or without assistive devices."
+            },
+            "25": {
+                "title": "growth/development care",
+                "description": "Activities that promote progressive maturation in relation to age such as measuring weight, height, and head circumference and stimulating achievement of developmental milestones."
+            },
+            "27": {
+                "title": "home",
+                "description": "Place of residence."
+            },
+            "28": {
+                "title": "interaction",
+                "description": "Reciprocal action or influence among people including parent-child, parent-teacher, and nurse-client."
+            },
+            "29": {
+                "title": "laboratory findings",
+                "description": "Results of fluid and tissue tests such as urine and blood analysis."
+            },
+            "30": {
+                "title": "legal system",
+                "description": "Authority, rules of conduct, or administration of the law."
+            },
+            "31": {
+                "title": "medical/dental care",
+                "description": "Assessment/diagnosis and treatment provided by physicians, dentists, and their staff or assistants."
+            },
+            "32": {
+                "title": "medication action/side effects",
+                "description": "Positive and/or negative consequences of medications."
+            },
+            "33": {
+                "title": "medication administration",
+                "description": "Activities that involve applying or giving medications and that are completed by clients, parents/caregivers, or health care practitioners."
+            },
+            "34": {
+                "title": "medication set-up",
+                "description": "Act of preparing for medication administration by filling/checking an oral medication organizer, prefilling syringes, or inserting intravenous access devices."
+            },
+            "35": {
+                "title": "mobility/transfers",
+                "description": "Body movements that change position or allow participation in activities such as walking."
+            },
+            "38": {
+                "title": "nutritionist care",
+                "description": "Assessment/diagnosis and treatment provided by nutritionists/registered dieticians and their staff or assistants."
+            },
+            "39": {
+                "title": "ostomy care",
+                "description": "Activities to manage elimination of urine or stool through artificial openings such as a colostomy and ileostomy."
+            },
+            "40": {
+                "title": "other community resources",
+                "description": "Organizations or groups that offer goods or services not specifically identified in other targets such as exercise facilities, food pantries/distribution centers, or faith communities."
+            },
+            "41": {
+                "title": "personal hygiene",
+                "description": "Individual grooming activities such as bathing, shampooing, and toileting."
+            },
+            "42": {
+                "title": "positioning",
+                "description": "Alignment of the body to promote comfort and function."
+            },
+            "44": {
+                "title": "relaxation/breathing techniques",
+                "description": "Activities that relieve muscle tension, induce a quieting body response, and rebuild energy resources such as deep breathing exercises, guided imagery, meditation, and massage."
+            },
+            "45": {
+                "title": "rest/sleep",
+                "description": "Periodic state of quiet and varying degrees of consciousness."
+            },
+            "46": {
+                "title": "safety",
+                "description": "Freedom from risk, the occurrence of injury, or loss."
+            },
+            "47": {
+                "title": "screening procedures",
+                "description": "Evaluation strategies used to identify risk for conditions, diagnose disease early, and monitor change/progression over time."
+            },
+            "48": {
+                "title": "sickness/injury care",
+                "description": "Activities in response to illness or accidents such as first aid and temperature taking."
+            },
+            "49": {
+                "title": "signs/symptoms-mental/emotional",
+                "description": "Objective or subjective evidence of mental/emotional health problems such as depression, confusion, or agitation."
+            },
+            "50": {
+                "title": "signs/symptoms-physical",
+                "description": "Objective or subjective evidence of physical health problems such as fever, sudden weight loss, or statement of pain."
+            },
+            "51": {
+                "title": "skin care",
+                "description": "Activities that promote skin integrity such as application of lotion and massage."
+            },
+            "52": {
+                "title": "social work/counseling care",
+                "description": "Assessment/diagnosis and treatment provided by social workers, counselors, and their staff or assistants."
+            },
+            "53": {
+                "title": "specimen collection",
+                "description": "Activities designed to obtain samples of human and animal tissue, fluids, secretions, or excreta such as blood, urine, stool, sputum, and drainage."
+            },
+            "54": {
+                "title": "spiritual care",
+                "description": "Activities that promote personal serenity and comfort and involve spiritual concerns/practices."
+            },
+            "55": {
+                "title": "stimulation/nurturance",
+                "description": "Activities that promote healthy physical, intellectual, and emotional development."
+            },
+            "56": {
+                "title": "stress management",
+                "description": "Cognitive, emotional, and physical activities that promote healthy functioning during difficult life circumstances."
+            },
+            "58": {
+                "title": "supplies",
+                "description": "Disposable items used while providing care such as dressings, syringes, tubing, diapers, and baby bottles."
+            },
+            "59": {
+                "title": "support group",
+                "description": "Organized sources of information and assistance such as focused classes and organizations, telephone reassurance, and reliable Internet sites that address a specific topic such as parenting, alcoholism, obesity, and Alzheimer's disease."
+            },
+            "60": {
+                "title": "support system",
+                "description": "Circle of family, friends, and associates that provide love, care, and assistance to promote health and manage illness."
+            },
+            "61": {
+                "title": "transportation",
+                "description": "Methods of travel such as a car, bus, taxi, scooter, or cart."
+            },
+            "62": {
+                "title": "wellness",
+                "description": "Practices that promote physical and mental health such as exercise, nutrition, and immunizations."
+            },
+            "63": {
+                "title": "other",
+                "description": "Persons, places, things, or activities not identified in this list."
+            },
+            "64": {
+                "title": "anger management",
+                "description": "Activities that decrease or control negative feelings and interactions, including violence."
+            },
+            "65": {
+                "title": "community outreach worker services",
+                "description": "Assistance with managing health care, transportation, household, and child/adult care responsibilities provided by qualified employees under the supervision of professional health care providers."
+            },
+            "66": {
+                "title": "continuity of care",
+                "description": "Communication of information among providers/organizations to provide safe and effective care and decrease duplication of efforts/services."
+            },
+            "67": {
+                "title": "dietary management",
+                "description": "Nourishment with balanced food and fluids that sustain life, provide energy, and promote growth and health."
+            },
+            "68": {
+                "title": "end-of-life care",
+                "description": "Activities that provide physical comfort and emotional calm for those who are dying by involving/including family, friends, spiritual concerns, rituals, pain control, and physical care."
+            },
+            "69": {
+                "title": "genetics",
+                "description": "Diagnosis, consultation, and procedures intended to prevent, identify, or treat birth defects, congenital anomalies, or conditions."
+            },
+            "70": {
+                "title": "homemaking/housekeeping",
+                "description": "Management of activities such as cleaning, laundry, and food preparation in the home or the health care facility."
+            },
+            "71": {
+                "title": "infection precautions",
+                "description": "Activities that decrease the incidence and transmission of contagious disease such as hand washing, isolation, specimen collection, contact follow—up, reporting procedures, and environmental control."
+            },
+            "72": {
+                "title": "interpreter/translator services",
+                "description": "Assistance with verbal or written communication in other languages provided by qualified employees who are under the supervision of professional health care practitioners."
+            },
+            "73": {
+                "title": "medication coordination/ordering",
+                "description": "Communication with those who prescribe and dispense medications and the individual/family/community support systems to ensure that appropriate medications and supplies are obtained in a timely manner."
+            },
+            "74": {
+                "title": "medication prescription",
+                "description": "A formalized pharmaceutical order/official request for medications."
+            },
+            "75": {
+                "title": "nursing care",
+                "description": "Assessment/diagnosis and treatment provided by nurses and their staff or assistants."
+            },
+            "76": {
+                "title": "occupational therapy care",
+                "description": "Assessment/diagnosis and treatment provided by occupational therapists and their staff or assistants."
+            },
+            "77": {
+                "title": "paraprofessional/aide care",
+                "description": "Assistance provided by qualified aides, home health aides, and nursing assistants under the supervision of professional health care practitioners."
+            },
+            "78": {
+                "title": "physical therapy care",
+                "description": "Assessment/diagnosis and treatment provided by physical therapists and their staff or assistants."
+            },
+            "79": {
+                "title": "recreational therapy care",
+                "description": "Assessment/diagnosis and treatment provided by recreational therapists and their staff or assistants."
+            },
+            "80": {
+                "title": "respiratory care",
+                "description": "Activities that promote respiratory or pulmonary function such as suctioning and nebulizer treatments."
+            },
+            "81": {
+                "title": "respiratory therapy care",
+                "description": "Assessment/diagnosis and treatment provided by respiratory therapists and staff or assistants."
+            },
+            "82": {
+                "title": "speech and language pathology care",
+                "description": "Assessment/diagnosis and treatment provided by speech and language pathologists and their staff or assistants."
+            },
+            "83": {
+                "title": "substance use cessation",
+                "description": "Activities that promote discontinuing use of harmful/addicting materials."
+            },
+            "01": {
+                "title": "anatomy/physiology",
+                "description": "Structure and function of the human body."
+            },
+            "02": {
+                "title": "behavior modification",
+                "description": "Activities that change habits, conduct, or patterns of action."
+            },
+            "03": {
+                "title": "bladder care",
+                "description": "Activities that promote urinary bladder function such as bladder retraining, catheter changes, and catheter irrigation."
+            },
+            "04": {
+                "title": "bonding/attachment",
+                "description": "A mutual, positive relationship between two people such as a parent/caregiver and an infant/child."
+            },
+            "05": {
+                "title": "bowel care",
+                "description": "Activities that promote bowel function such as bowel training and enemas."
+            },
+            "07": {
+                "title": "cardiac care",
+                "description": "Activities that promote cardiac or circulatory function such as energy conservation and fluid balance."
+            },
+            "08": {
+                "title": "caretaking/parenting skills",
+                "description": "Activities such as feeding, bathing, discipline, nurturing, and stimulation provided to a dependent child or adult."
+            },
+            "09": {
+                "title": "cast care",
+                "description": "Activities that promote cleanliness, dryness, support, alignment, and relief of pain, pressure, and constriction of an injured body part immobilized by a cast, splint, or other device."
+            }
+        }
+    },
+    "problemRatingScale": {
+        "title": "Problem Rating Scale for Outcomes",
+        "ratings": {
+            "0": {
+                "title": "Knowledge",
+                "description": "Ability of the client to remember and interpret information.",
+                "scale": {
+                    "0": {
+                        "title": "No knowledge"
+                    },
+                    "1": {
+                        "title": "Minimal knowledge"
+                    },
+                    "2": {
+                        "title": "Basic knowledge"
+                    },
+                    "3": {
+                        "title": "Adequate knowledge"
+                    },
+                    "4": {
+                        "title": "Superior knowledge"
+                    }
+                }
+            },
+            "1": {
+                "title": "Behavior",
+                "description": "Observable responses, actions, or activities of the client fitting the occasion or purpose.",
+                "scale": {
+                    "0": {
+                        "title": "Not appropriate behavior"
+                    },
+                    "1": {
+                        "title": "Rarely appropriate behavior"
+                    },
+                    "2": {
+                        "title": "Inconsistently appropriate behavior"
+                    },
+                    "3": {
+                        "title": "Usually appropriate behavior"
+                    },
+                    "4": {
+                        "title": "Consistently appropriate behavior"
+                    }
+                }
+            },
+            "2": {
+                "title": "Status",
+                "description": "Condition of the client in relation to objective and subjective defining characteristics.",
+                "scale": {
+                    "0": {
+                        "title": "Extreme signs/symptoms"
+                    },
+                    "1": {
+                        "title": "Severe signs/symptoms"
+                    },
+                    "2": {
+                        "title": "Moderate signs/symptoms"
+                    },
+                    "3": {
+                        "title": "Minimal signs/symptoms"
+                    },
+                    "4": {
+                        "title": "No signs/symptoms"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/boot/i18n.ts
+++ b/src/boot/i18n.ts
@@ -162,14 +162,24 @@ export default boot(async ({ app, store }) => {  // load terminology
         throw new Error("locale or filename undefined");
       }
 
-      const response = await fetch(filename);
+      /* Anything thrown in here aborts the whole boot chain, and Quasar then
+      never mounts the app — one unreadable terminology file would take the
+      entire UI down instead of degrading a single language. Checking
+      response.ok is not enough on its own either: a server that answers
+      missing files with an SPA fallback replies 200 with an HTML body, which
+      then fails inside JSON.parse. */
+      try {
+        const response = await fetch(filename);
 
-      if (response.ok) {
-        const text = await response.text();
-        const terminology = JSON.parse(text);
+        if (!response.ok) {
+          console.warn(filename + " not found");
+          return;
+        }
+
+        const terminology = JSON.parse(await response.text());
         (i18n.global.messages as any).value[locale].terminology = makeTerminologyWithMaps(terminology);
-      } else {
-        console.warn(filename + " not found");
+      } catch (error) {
+        console.error("could not load terminology from " + filename, error);
       }
     })
   );


### PR DESCRIPTION
## The problem

A fresh clone cannot start. `src/boot/i18n.ts` fetches `terminology_EN.json` and `terminology_DE.json`, but neither file is in the repository.

15f2896 (*load terminology dynamically instead of statically*) removed them from `src/i18n/` and added `/public/*.json` to `.gitignore`; the replacements under `public/` were never committed.

To reproduce on current `master`:

```bash
git clone https://github.com/coop-care/web-app.git && cd web-app
npm install
npm run dev:demo
```

The page stays blank and the console shows:

```
[Quasar] boot error: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

That is `JSON.parse` receiving the dev server's `index.html` fallback instead of the file it asked for.

## Why it takes the whole app down

Anything thrown inside a boot file aborts Quasar's boot chain, and `client-entry.js` returns before `app.mount('#q-app')`. So a missing data file does not cost one language — it costs the entire UI.

## What this changes

- Restores both files from 15f2896^ into `public/`, force-added past the ignore rule. `.gitignore` gains an exception so the same thing cannot happen again silently.
- Wraps each fetch in its own `try`/`catch`, so an unreadable terminology degrades one language instead of the app.

Checking `response.ok` alone is not sufficient, which is worth keeping in mind beyond this fix: a server that answers missing files with an SPA fallback — as the dev server and most static hosts do — returns **200** with an HTML body, and the failure surfaces inside `JSON.parse`.

## Note on the data

The copies in the archived `coop-care/terminology` repository are **not** interchangeable with these: they store `domains`, `problems` and `targets` as arrays, whereas `objectsToArrays()` in `src/helper/terminology.ts` expects objects keyed by code. These come from 15f2896^, so they are the exact files the loader was written against.

## Verified

Cloned the branch fresh and confirmed both files are present and that `domains` is keyed by code (`01`, `02`, `03`), which is what `makeTerminologyWithMaps()` consumes.